### PR TITLE
Implement memory reclamation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cache/clangd/index
 build
 include/mlir/Interpreter/InterpreterOpInterface.cpp.inc
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 # Enable RTTI if needed
 set(LLVM_ENABLE_RTTI ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
 
 # Add subdirectories
 add_subdirectory(lib)
@@ -73,3 +74,9 @@ install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/MLIConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/MLIConfigVersion.cmake"
     DESTINATION lib/cmake/MLI)
+
+option(ENABLE_TESTING "Enable Testing" OFF)
+if(ENABLE_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/include/mlir/Interpreter/MemoryManager.h
+++ b/include/mlir/Interpreter/MemoryManager.h
@@ -1,14 +1,10 @@
 #ifndef MLIR_INTERPRETER_MEMORYMANAGER_H
 #define MLIR_INTERPRETER_MEMORYMANAGER_H
 
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
+#include <algorithm>
 #include <list>
 #include <vector>
 #include <map>
-#include <new>
-#include <stdexcept>
 
 namespace mlir{
 
@@ -66,12 +62,15 @@ public:
   void free(uint64_t addr) override {
     uint64_t freedSize = allocations[addr].size;
     allocations.erase(addr);
-    
+
     // Consolidate blocks by reclaiming freed memory
     // Find supremum/infimum of freed block located at addr
     // (i.e. closest available blocks on either side of freed block)
-    auto right = freeBlocks.begin();
-    while (right != freeBlocks.end() && right->first < addr) { ++right; }
+    auto right = std::upper_bound(freeBlocks.begin(), freeBlocks.end(), addr,
+        [](const uint64_t a, const std::pair<uint64_t, uint64_t>& b) {
+            return a < b.first;
+        }
+    );
     auto left = std::prev(right);
 
     // Test if the adjacent blocks of the freed block are available
@@ -82,6 +81,11 @@ public:
     if (openLeft && openRight) {
         // Case I: Incorporate both the freed block and right into left
         left->second += (freedSize + right->second);
+        // The right pointer is now redundant, so we can delete it
+        // Ensure that next != right to prevent dangling pointer
+        if (next == right) {
+            next = ++next == freeBlocks.end() ? freeBlocks.begin() : next;
+        }
         freeBlocks.erase(right); // made redundant by expansion
     }
     else if (openLeft && !openRight) {
@@ -91,7 +95,7 @@ public:
     else if (!openLeft && openRight)  {
         // Case III: Incorporate the freed block into right
         right->first = addr;
-        right->second += freedSize; 
+        right->second += freedSize;
     }
     else {
         // Case IV: Bookended by allocated memory, create new entry between left and right

--- a/include/mlir/Interpreter/MemoryManager.h
+++ b/include/mlir/Interpreter/MemoryManager.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <list>
 #include <vector>
 #include <map>
 #include <new>
@@ -27,37 +28,78 @@ public:
 ///  - Performs simple bounds checking on read/write.
 class SimpleMemoryManager : public MemoryManager {
 public:
-  explicit SimpleMemoryManager(size_t initialSize = 1024 * 1024)
-      : nextFreeAddress(0) {
+  explicit SimpleMemoryManager(size_t initialSize = 1024 * 1024) {
     // Pre-allocate our contiguous memory space
     Mem.resize(initialSize, 0);
+    // NOTE: For debugging
+    freeBlocks = {std::make_pair(0, initialSize)};
+    next = freeBlocks.begin();
   }
 
   /// Allocate 'size' bytes. We return an offset (uint64_t) into our single buffer.
   /// Throws std::bad_alloc if we can’t fit the allocation.
   uint64_t allocate(size_t size) override {
-    // Check if we have room in 'mem'
-    if (nextFreeAddress + size > Mem.size())
-      throw std::bad_alloc();
+    // Keep track of first examined block
+    auto oldNext = next;
+    do {
+        if (next->second >= size) {
+            // Current block is large enough for allocation
+            uint64_t addr = next->first;
+            Allocation allocInfo;
+            allocInfo.size = size;
+            allocations[addr] = allocInfo;
 
-    uint64_t addr = nextFreeAddress;
-    nextFreeAddress += size;
+            // Update block to reflect allocation
+            next->first += size;
+            next->second -= size;
+            return addr;
+        }
+        // Advance list, circling back if at end
+        next = ++next == freeBlocks.end() ? freeBlocks.begin() : next;
+    } while (next != oldNext);
 
-    Allocation allocInfo;
-    allocInfo.size = size;
-    allocations[addr] = allocInfo;
-
-    return addr;
+    // We've traversed all available blocks, and none are large enough
+    throw std::bad_alloc();
   }
 
   /// Free is a no-op in this naive implementation, but we do erase the allocation
   /// from our map to prevent bounds checking from succeeding if a region is freed.
   void free(uint64_t addr) override {
-    auto it = allocations.find(addr);
-    if (it != allocations.end()) {
-      allocations.erase(it);
+    uint64_t freedSize = allocations[addr].size;
+    allocations.erase(addr);
+    
+    // Consolidate blocks by reclaiming freed memory
+    // Find supremum/infimum of freed block located at addr
+    // (i.e. closest available blocks on either side of freed block)
+    auto right = freeBlocks.begin();
+    while (right != freeBlocks.end() && right->first < addr) { ++right; }
+    auto left = std::prev(right);
+
+    // Test if the adjacent blocks of the freed block are available
+    // This determines how the blocks can be consolidated
+    bool openLeft = left->first+left->second == addr;
+    bool openRight = right->first == addr + freedSize;
+
+    if (openLeft && openRight) {
+        // Case I: Incorporate both the freed block and r into l
+        left->second += (freedSize + right->second);
+        freeBlocks.erase(right); // made redundant by expansion
     }
-    // TODO: Eventually add support for reusing freed memory.
+    else if (openLeft && !openRight) {
+        // Case II: Incorporate the freed block into l
+        left->second += freedSize;
+    }
+    else if (!openLeft && openRight)  {
+        // Case III: Incorporate the freed block into r
+        right->first = addr;
+        right->second += freedSize; 
+    }
+    else {
+        // Case IV: Bookended by allocated memory, create new entry between l and r
+        auto newBlock = std::make_pair(addr, freedSize);
+        freeBlocks.insert(right, newBlock);
+    }
+
   }
 
   /// Read 'size' bytes from address 'addr' into 'dst'.
@@ -111,11 +153,16 @@ private:
   // A single contiguous buffer
   std::vector<char> Mem;
 
-  // The offset for the next allocation.
-  uint64_t nextFreeAddress;
+  // All available memory blocks, available as pairs [beginAddr, size]
+  std::list<std::pair<uint64_t, uint64_t>> freeBlocks;
+
+  // Iterator to the last allocated block in memory
+  // Used for "next-block" allocation strategy
+  std::list<std::pair<uint64_t, uint64_t>>::iterator next;
 
   // Map from "address" (offset) -> Allocation metadata
   std::map<uint64_t, Allocation> allocations;
+
 };
 }
 

--- a/include/mlir/Interpreter/MemoryManager.h
+++ b/include/mlir/Interpreter/MemoryManager.h
@@ -31,7 +31,6 @@ public:
   explicit SimpleMemoryManager(size_t initialSize = 1024 * 1024) {
     // Pre-allocate our contiguous memory space
     Mem.resize(initialSize, 0);
-    // NOTE: For debugging
     freeBlocks = {std::make_pair(0, initialSize)};
     next = freeBlocks.begin();
   }
@@ -62,8 +61,8 @@ public:
     throw std::bad_alloc();
   }
 
-  /// Free is a no-op in this naive implementation, but we do erase the allocation
-  /// from our map to prevent bounds checking from succeeding if a region is freed.
+  /// Remove allocation associated with addr from map
+  /// Also reclaims freed memory for future allocations
   void free(uint64_t addr) override {
     uint64_t freedSize = allocations[addr].size;
     allocations.erase(addr);
@@ -81,21 +80,21 @@ public:
     bool openRight = right->first == addr + freedSize;
 
     if (openLeft && openRight) {
-        // Case I: Incorporate both the freed block and r into l
+        // Case I: Incorporate both the freed block and right into left
         left->second += (freedSize + right->second);
         freeBlocks.erase(right); // made redundant by expansion
     }
     else if (openLeft && !openRight) {
-        // Case II: Incorporate the freed block into l
+        // Case II: Incorporate the freed block into left
         left->second += freedSize;
     }
     else if (!openLeft && openRight)  {
-        // Case III: Incorporate the freed block into r
+        // Case III: Incorporate the freed block into right
         right->first = addr;
         right->second += freedSize; 
     }
     else {
-        // Case IV: Bookended by allocated memory, create new entry between l and r
+        // Case IV: Bookended by allocated memory, create new entry between left and right
         auto newBlock = std::make_pair(addr, freedSize);
         freeBlocks.insert(right, newBlock);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (ENABLE_TESTING)
+   add_subdirectory(MemManager)
+endif()

--- a/test/MemManager/CMakeLists.txt
+++ b/test/MemManager/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (ENABLE_TESTING)
+  add_test(NAME MEM_MANAGER COMMAND memManager)
+endif()

--- a/test/MemManager/testMemory.cc
+++ b/test/MemManager/testMemory.cc
@@ -1,0 +1,84 @@
+#include <cassert>
+#include "mlir/Interpreter/MemoryManager.h"
+
+#define NUM_BLOCKS 3
+
+using namespace mlir;
+
+// We need to test if consolidating adjacent free blocks works
+// Do this by testing if we can allocate a region spanning the width of combined blocks
+// Throws an uncaught exception if allocate's exception and throwException disagree
+uint64_t testAlloc(SimpleMemoryManager& mem, const uint64_t size, bool throwException = false) {
+    uint64_t addr;
+    try {
+        addr = mem.allocate(size);
+        // alloc doesn't throw exception, determine if this is good or bad
+        if (throwException) throw std::runtime_error("No exception thrown!");
+        mem.free(addr);
+    }
+    catch (std::exception& e) {
+        // Throw a second exception if the test fails
+        if (!throwException || std::string(e.what()) == "No exception thrown") throw std::exception();
+    }
+    return addr;
+}
+
+// Set up memory manager to model each of the four removal scenarios
+void prepareMemManager(SimpleMemoryManager& mem, const uint64_t* blockSizes, bool openLeft, bool openRight) {
+    uint64_t addresses[NUM_BLOCKS];
+
+    for (int i = 0; i < NUM_BLOCKS; i++) {
+        addresses[i] = mem.allocate(blockSizes[i]);
+    }
+
+    if (openLeft) mem.free(addresses[0]);
+    if (openRight) mem.free(addresses[2]);
+
+}
+
+int main() {
+    const uint64_t memSize = 100;
+    const uint64_t blockSizes[NUM_BLOCKS] = {20, 50, 30};
+
+    // Case I: Free a region blocked on both sides, no consolidation of freed blocks
+    SimpleMemoryManager mem1 = SimpleMemoryManager(memSize);
+    prepareMemManager(mem1, &blockSizes[0], false, false);
+
+    // Case II: Free a region blocked only on left side, consolidate freed block w/ right neighbor
+    SimpleMemoryManager mem2 = SimpleMemoryManager(memSize);
+    prepareMemManager(mem2, &blockSizes[0], false, true);
+
+    // Case III: Free a region blocked only on right side, consolidate freed block w/ left neighbor
+    SimpleMemoryManager mem3 = SimpleMemoryManager(memSize);
+    prepareMemManager(mem3, &blockSizes[0], true, false);
+
+    // Case IV: Free a region blocked on neither side, consolidate freed block w/ both neighbors
+    SimpleMemoryManager mem4 = SimpleMemoryManager(memSize);
+    prepareMemManager(mem4, &blockSizes[0], true, true); 
+
+    const uint64_t middleAddr = 20;
+
+    // Case I
+    mem1.free(middleAddr);
+    assert(testAlloc(mem1, blockSizes[1], false) == middleAddr && "MemManager can't reclaim freed block");
+    testAlloc(mem1, memSize, true); // should fail, not enough space
+
+    // Case II
+    mem2.free(middleAddr);
+    assert(testAlloc(mem2, blockSizes[1], false) == middleAddr && "MemManager can't reclaim freed block");
+    assert(testAlloc(mem2, blockSizes[1]+blockSizes[2], false) == middleAddr && "MemManager can't consolidate block with right neighbor");
+    testAlloc(mem2, memSize, true); // should fail, not enough space
+
+    // Case III
+    mem3.free(middleAddr);
+    assert(testAlloc(mem3, blockSizes[1], false) == middleAddr - blockSizes[0] && "MemManager can't reclaim freed block");
+    assert(testAlloc(mem3, blockSizes[0]+blockSizes[1], false) == middleAddr - blockSizes[0] && "MemManager can't consolidate block with left neighbor");
+    testAlloc(mem3, memSize, true); // should fail, not enough space
+    
+    // Case IV
+    mem4.free(middleAddr);
+    assert(testAlloc(mem4, blockSizes[1], false) == 0 && "MemManager can't reclaim freed block");
+    assert(testAlloc(mem4, memSize, false) == 0 && "MemManager can't consolidate block with both neighbors");
+
+    return 0;
+}


### PR DESCRIPTION
Allows for `SimpleMemManager` to reclaim memory upon `free`, potentially consolidating it with adjacent free blocks. This should hopefully stave off fragmentation-related issues.