### PR TITLE
Automatically format files during precommit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,10 +32,17 @@ BraceWrapping:
   BeforeWhile: false
 BreakConstructorInitializers: BeforeColon
 FixNamespaceComments: true
+IndentCaseBlocks: true
+IndentCaseLabels: true
 IndentWidth: 4
 IndentWrappedFunctionNames: true
 SortIncludes: true
-SpaceBeforeParens: Never
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
 SpacesInAngles: Never
 SpacesInParentheses: false
 SpacesInSquareBrackets: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,73 @@
+BasedOnStyle: LLVM
+Standard: c++17
+ColumnLimit: 132
+UseTab: Never
+UseCRLF: false
+AlignEscapedNewlines: Left
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+BinPackArguments: false
+AllowAllArgumentsOnNextLine: true
+BinPackParameters: false
+AllowAllParametersOfDeclarationOnNextLine: true
+BitFieldColonSpacing: Both
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  BeforeCatch: false
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
+BreakConstructorInitializers: BeforeColon
+FixNamespaceComments: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+SortIncludes: true
+SpaceBeforeParens: Never
+SpacesInAngles: Never
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpacesInConditionalStatement: true
+SpacesInCStyleCastParentheses: false
+SpaceInEmptyParentheses: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCaseColon: false
+SpaceBeforeAssignmentOperators: true
+SpaceAfterLogicalNot: false
+SpaceAfterCStyleCast: true
+SpaceAroundPointerQualifiers: Default
+PointerAlignment: Left
+DerivePointerAlignment: false
+ReferenceAlignment: Pointer
+InsertTrailingCommas: Wrapped
+MaxEmptyLinesToKeep: 1
+AlignTrailingComments: true
+SpacesBeforeTrailingComments: 2
+AlignArrayOfStructures: Right
+AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
+AlignConsecutiveDeclarations: Consecutive
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
+AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
+AlignAfterOpenBracket: BlockIndent
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+AlignOperands: Align
+ReflowComments: false
+SeparateDefinitionBlocks: Always
+EmptyLineBeforeAccessModifier: LogicalBlock

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,321 @@
+#!/bin/bash
+#
+# This pre-commit hook reformats text files to meet coding guidelines.
+#
+# Based on https://github.com/rocm/rocBLAS
+#
+# shellcheck enable=all
+# shellcheck disable=2034,2059,2064,2250,2310,2312
+
+set_shell_options() {
+    set -eEu -o pipefail
+    shopt -s nocasematch
+    export PATH=$PATH:/usr/bin:/bin
+    exec >&2
+}
+
+# Terminal colors
+set_colors() {
+    if [[ -z ${NO_COLOR+x} ]] && tty -s <&2; then
+        RED="\033[91m"
+        YELLOW="\033[93m"
+        GREEN="\033[92m"
+        END="\033[0m"
+    else
+        RED=
+        YELLOW=
+        GREEN=
+        END=
+    fi
+}
+
+usage() {
+    cat<<EOF
+Usage: pre-commit [ --reformat] [ --nostage ] [ file1 ] [ file2 ] [ file3 ] ...
+
+Format files prior to commit so that they match style guidelines
+
+Normally called before commit, but if files are explicitly specified, reformats
+them in-place without respect to commits.
+
+Options:
+   --reformat   Reformat all files in the source tree, rather than staged files
+   --nostage    Do not add files modified by pre-commit to the staging area
+EOF
+    exit 1
+}
+
+# Parse command-line options
+parse_options() {
+    FILES=()
+    REFORMAT=
+    NOSTAGE=
+    EXPLICIT_FILES=
+    local endopts=
+    for opt in "$@"; do
+        if [[ -n $endopts ]]; then
+            FILES+=("$opt")
+        else
+            case $opt in
+                --)         endopts=1  ;;
+                --reformat) REFORMAT=1 ;;
+                --nostage)  NOSTAGE=1  ;;
+                -*)         usage      ;;
+                *)          FILES+=("$opt")
+            esac
+        fi
+    done
+    if [[ ${#FILES[@]} -ne 0 ]]; then
+        EXPLICIT_FILES=1
+        NOSTAGE=1
+    fi
+}
+
+# How to install a package
+howto_install() {
+    package=$1
+
+    INSTALL=
+    if [[ $OSTYPE = darwin* ]]; then
+        if command -v brew >/dev/null; then
+            INSTALL="brew install $package"
+        fi
+    elif [[ $OSTYPE = linux* ]]; then
+        if [[ -f /etc/redhat-release ]]; then
+            if command -v dnf >/dev/null; then
+                INSTALL="sudo dnf install $package"
+            elif command -v yum >/dev/null; then
+                if [[ $package = shellcheck ]]; then
+                    package=ShellCheck
+                fi
+                INSTALL="sudo yum install $package"
+            fi
+        elif [[ -f /etc/debian_version ]] && command -v apt-get >/dev/null; then
+            INSTALL="sudo apt-get install $package"
+        fi
+    fi
+    if [[ -n $INSTALL ]]; then
+        printf "${YELLOW}\nTo install $package, run:\n\n%s\n\n${END}" "$INSTALL"
+    else
+        printf "${YELLOW}\nInstall $package and make sure it is in PATH.\n\n${END}"
+    fi
+}
+
+# Check for existence of clang-format or print error message on how to install
+check_clang_format() {
+    if ! command -v clang-format >/dev/null; then
+        printf "${RED}\nError: clang-format not found\n${END}"
+        howto_install clang-format
+        exit 1
+    fi
+}
+
+# Test a file for changes and add them to the Git commit if changed
+detect_change() {
+    if ! cmp -s "$1" "$2"; then
+        printf "${YELLOW}$3${END}\n" "$1"
+        cp -f "$2" "$1"
+        if [[ -z $EXPLICIT_FILES && -z $NOSTAGE ]]; then
+            git add -u "$1"
+        fi
+    fi
+}
+
+# Generate list of modified files
+# If --reformat is used, all files are reformatted
+get_files() {
+    if [[ -n $EXPLICIT_FILES ]]; then
+        # cd to this script's directory before running clang-format
+        # so that the .clang-format from this script's repo is used
+        REPO=$(dirname "$0")
+    else
+        # Do everything from top level
+        REPO=$(git rev-parse --show-toplevel)
+        cd "$REPO"
+        if [[ -n $REFORMAT ]]; then
+            while IFS= read -r -d $'\0' FILE; do
+                FILES+=("$FILE")
+            done < <(git ls-files -z --exclude-standard)
+        else
+            if git rev-parse --verify HEAD >/dev/null 2>&1; then
+                against=HEAD
+            else
+                # Initial commit: diff against initial commit
+                against=$(git log --reverse --pretty=format:%H | head -1)
+            fi
+            while IFS= read -r -d $'\0' FILE; do
+                FILES+=("$FILE")
+            done < <(git diff-index -z --cached --name-only "$against")
+        fi
+    fi
+}
+
+# Test if argument is a text file
+# git grep tests whether Git considers it a text file
+# If files were explicitly specified, they are assumed to be text files
+is_text_file() {
+    [[ -n $EXPLICIT_FILES ]] || git grep -Iqe . -- "$1"
+}
+
+# Test if argument is a C/C++ file
+is_cxx_file() {
+    local file=$1
+    trap "$(shopt -p nocasematch)" RETURN
+    shopt -u nocasematch
+    case $file in
+        *.c|*.h|*.cc|*.cpp) true ;;
+       *.hpp)  printf "${RED}${file}: Error: C++ header files should have .h extension instead of .hpp${END}\n\n"
+               errors=true ;;
+        *.cxx) printf "${RED}${file}: Error: C++ source files should have .cc extension instead of .cxx${END}\n\n"
+               errors=true ;;
+        *.C)   printf "${RED}${file}: Error: C++ source files should have .cc extension instead of .C${END}\n\n"
+               errors=true ;;
+        *) false
+    esac
+}
+
+
+# Check for redundant C++ directives
+check_override_final() {
+    local file=$1 err
+    if err=$(grep -Hno "^[^/].*\bvirtual\b.*\boverride\b" "$file"); then
+        printf "${err}\n${RED}Error: virtual keyword is redundant with override directive${END}\n\n"
+        errors=true
+    elif err=$(grep -Hno "^[^/].*\bvirtual\b.*\bfinal\b" "$file"); then
+        printf "${err}\n${RED}Error: If final directive is used, virtual should not be specified${END}\n\n"
+        errors=true
+    elif err=$(grep -Hno "^[^/].*\boverride\b.*\bfinal\b" "$file") || err=$(grep -Hno "\bfinal\b.*\boverride\b" "$file"); then
+        printf "${err}\n${RED}Error: If final directive is used, override is redundant${END}\n\n"
+        errors=true
+    fi
+}
+
+# Check for correct magic and filename extensions
+# filename extension mime-type shebang
+check_extension() {
+    local file=$1 ext=$2 mimetype=$3 shebang=$4 instead
+    trap "$(shopt -p nocasematch)" RETURN
+    shopt -u nocasematch
+    if [[ ! $(file -Lb --mime-type "$1") =~ ${mimetype} ]]; then
+        if [[ $file = *$ext ]]; then
+            printf "\n${RED}${file}: Error: Not recognized as ${mimetype}.\n${shebang:+Make sure that shebang ${shebang} is at the top of ${file}.\n}${END}"
+            errors=true
+        fi
+    elif [[ $file != *$ext ]]; then
+        instead=$( if [[ $file = *.* ]]; then echo "instead of .${file##*.}"; fi )
+        printf "\n${RED}${file}: Error: ${mimetype} filenames should have $ext extension ${instead}${END}\n"
+        errors=true
+    fi
+}
+
+reformat_files() {
+    # Temporary file for reformatting
+    temp=$(mktemp)
+    trap 'rm -f "$temp"' EXIT
+
+    # Get the list of files into FILES
+    get_files
+
+    # Fix formatting on text files
+    if [[ ${#FILES[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    errors=false
+    shellcheck_warning=
+
+# Fix formatting on text files
+    for file in "${FILES[@]}"; do
+        if [[ -f $file ]] && is_text_file "$file"; then
+            # Replace non-ASCII characters with ASCII equivalents
+            if ! iconv -s -f utf-8 -t ascii//TRANSLIT "$file" > "$temp"; then
+                cat <<EOF
+${YELLOW}iconv -f utf-8 -t ascii//TRANSLIT "$file" > "$temp"${END}
+EOF
+                iconv -f utf-8 -t ascii//TRANSLIT "$file" > "$temp" || true
+                fold -s -w79 <<EOF
+${RED}Some non-ASCII characters in $file could not be converted into equivalent
+ASCII characters. Please replace non-ASCII characters in $file and try again.${END}
+EOF
+                exit 1
+            fi
+
+            detect_change "$file" "$temp" "%s: Converting non-ASCII characters to ASCII equivalents"
+
+            # Change the copyright date at the top of any text files
+            perl -e ''
+            if perl -pe 'INIT { exit 1 if !-f $ARGV[0] || -B $ARGV[0]; $year = (localtime)[5] + 1900 } s/^([*\/#\/"*[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?(?=\s+Tactical Computing)/qq($1Copyright (C) $2@{[$year != $2 ? "-$year" : ""]})/ie if $. < 10' "$file" > "$temp"; then
+                detect_change "$file" "$temp" "%s: Changing copyright date"
+            fi
+
+            # Run clang-format on C/C++ files
+            if is_cxx_file "$file"; then
+                check_clang_format
+                (cd "$REPO" && clang-format) < "$file" > "$temp"
+                detect_change "$file" "$temp" "%s: Reformatting with clang-format according to coding guidelines"
+                check_override_final "$file"
+            fi
+
+            # Remove trailing whitespace at end of lines
+            sed -e 's/[[:space:]]*$//' < "$file" > "$temp"
+            detect_change "$file" "$temp" "%s: Removing trailing whitespace at line endings"
+
+            # Add missing newline at EOF
+            awk 1 < "$file" > "$temp"
+            detect_change "$file" "$temp" "%s: Adding missing newline at end of file"
+
+            # check filename extensions and magic
+            if [[ $file != **/pre-commit ]]; then
+                check_extension  "$file"  ".sh"  "^text/x-shellscript$"                   "#!/bin/bash"
+                check_extension  "$file"  ".py"  "^text/x-script\.python|text/x-python$"  "#!/usr/bin/env python3"
+                check_extension  "$file"  ".pl"  "^text/x-perl$"                          "#!/usr/bin/perl"
+            fi
+
+            # CMake-esque files
+            if [[ $file = "CMakeLists.txt" ]]; then
+                if command -v cmake-format >/dev/null 2>&1; then
+                    cmake-format  --line-width 131 --tab-size 4 --use-tabchars false --dangle-parens false -i "$file"
+                else
+                    printf "${RED}Error: cmake-format utility not found. %s not checked with cmake-format.${END}\n" "$file"
+                    exit 1
+                fi
+            fi
+
+            # Python files
+            if [[ $file = *.py ]]; then
+                if command -v flake8 >/dev/null 2>&1; then
+                    flake8 --max-line-length 131 "$file" || errors=true
+                else
+                    printf "${RED}Error: flake8 utility not found. %s not checked with flake8.${END}\n" "$file"
+                    printf "${YELLOW}\nTo Install flake8, type:\n\npip install flake8\n\n${END}"
+                    exit 1
+                fi
+            fi
+
+            # Shell scripts
+            if [[ $file = *.sh || $file = **/pre-commit ]]; then
+                if command -v shellcheck >/dev/null 2>&1 && shellcheck -o all -e2148 /dev/null >/dev/null 2>&1; then
+                    shellcheck -o all -e 1091,2059,2154,2248,2250,2312 "$file" || errors=true
+                else
+                    printf "${YELLOW}Warning: %s not checked with shellcheck.${END}\n" "$file"
+                    shellcheck_warning=1
+                fi
+            fi
+        fi
+    done
+
+    if [[ -n $shellcheck_warning ]]; then
+        printf "${YELLOW}\nWarning: shellcheck utility not found or not recent enough version.\n${END}"
+        howto_install shellcheck
+    fi
+
+    if [[ $errors = true ]]; then
+        exit 1
+    fi
+}
+
+# Main Program
+set_shell_options
+set_colors
+parse_options "$@"
+reformat_files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,20 @@
 # ===- CMakeLists.txt - MLI (MLIR Interpreter)
 #
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC All Rights Reserved
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
-# All Rights Reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
 cmake_minimum_required(VERSION 3.22)
-project(MLI VERSION 1.0.0 LANGUAGES C CXX)
+project(
+    MLI
+    VERSION 1.0.0
+    LANGUAGES C CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -26,12 +24,12 @@ add_definitions(${NO_RTTI})
 
 # Set default build type to RelWithDebInfo if not specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE
-      STRING "Choose the type of build." FORCE)
+    set(CMAKE_BUILD_TYPE
+        "RelWithDebInfo"
+        CACHE STRING "Choose the type of build." FORCE)
 
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
 # Find LLVM and MLIR
@@ -44,12 +42,10 @@ include(AddLLVM)
 include(AddMLIR)
 
 # Include directories
-include_directories(BEFORE
-  # Always prioritize the copies of files that are inside this
-  # repo over ones found from previous installations
-  ${CMAKE_SOURCE_DIR}/include
-  ${CMAKE_BINARY_DIR}/include
-)
+include_directories(
+    BEFORE
+    # Always prioritize the copies of files that are inside this repo over ones found from previous installations
+    ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include)
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 
@@ -63,46 +59,50 @@ add_subdirectory(lib)
 add_subdirectory(src)
 
 # Install include files
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.td" PATTERN "*.inc")
+install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "*.td"
+    PATTERN "*.inc")
 
 # Install and export the targets
-install(EXPORT MLITargets
-        FILE MLITargets.cmake
-        NAMESPACE MLI::
-        DESTINATION lib/cmake/MLI)
+install(
+    EXPORT MLITargets
+    FILE MLITargets.cmake
+    NAMESPACE MLI::
+    DESTINATION lib/cmake/MLI)
 
 # Generate and install package config files
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/MLIConfigVersion.cmake"
     VERSION "${PROJECT_VERSION}"
-    COMPATIBILITY AnyNewerVersion
-)
+    COMPATIBILITY AnyNewerVersion)
 
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/MLIConfig.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/MLIConfig.cmake"
-    INSTALL_DESTINATION lib/cmake/MLI)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/MLIConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/MLIConfig.cmake"
+                              INSTALL_DESTINATION lib/cmake/MLI)
 
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/MLIConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/MLIConfigVersion.cmake"
-    DESTINATION lib/cmake/MLI)
-    
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/MLIConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/MLIConfigVersion.cmake"
+        DESTINATION lib/cmake/MLI)
+
 option(ENABLE_TESTING "Enable Testing" OFF)
 option(ENABLE_POLYGEIST "Enable Polygeist" OFF)
 if(ENABLE_TESTING)
-  enable_testing()
-  if (ENABLE_POLYGEIST)
-    find_file(CGEIST cgeist PATHS $ENV{PATH})
-    if (CGEIST)
-		set(CGEIST "${CGEIST}" CACHE FILEPATH "Path to cgeist executable")
-        message(STATUS "Polygeist tests enabled, cgeist found at ${CGEIST}")
-    else()
-        message(WARNING "cgeist not found in \$PATH, Polygeist tests disabled")
+    enable_testing()
+    if(ENABLE_POLYGEIST)
+        find_file(CGEIST cgeist PATHS $ENV{PATH})
+        if(CGEIST)
+            set(CGEIST
+                "${CGEIST}"
+                CACHE FILEPATH "Path to cgeist executable")
+            message(STATUS "Polygeist tests enabled, cgeist found at ${CGEIST}")
+        else()
+            message(WARNING "cgeist not found in \$PATH, Polygeist tests disabled")
+        endif()
     endif()
-  endif()
-  add_subdirectory(test)
-  add_executable(memManager test/mem_manager/testMemory.cpp)
+    add_subdirectory(test)
+    add_executable(memManager test/mem_manager/testMemory.cpp)
 endif()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Out-of-Tree Interpreter for executing MLIR code. Based on [work](https://discour
 mkdir build && cd build
 cmake -G Ninja -DLLVM_DIR=/opt/homebrew/opt/llvm@19/lib/cmake/llvm -DMLIR_DIR=/opt/homebrew/opt/llvm@19/lib/cmake/mlir -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DCMAKE_BUILD_TYPE=RelWDebInfo ../ -DCMAKE_INSTALL_PREFIX=/opt/homebrew/opt/llvm@19
 ```
+If you plan on contributing to this repository, we suggest you run `git config core.hooksPath .githooks` after cloning the repository. This sets up the precommit hooks that automatically enforce coding standards.
 
 ## Building Polygeist
 We provide support for [Polygeist](http://polygeist.llvm.org), a C/C++ frontend that can emit MLIR source. This is optional for building `mli`, but is helpful if the user wants to work from C++ source files. Polygeist can be built by:

--- a/include/MLIExec.h
+++ b/include/MLIExec.h
@@ -10,250 +10,232 @@
 
 // Converts a command-line argument to an EvalValue based on the expected type
 static mlir::EvalValue convertArgToEvalValue(
-    const std::string& argStr,
-    mlir::Type argType,
-    mlir::Interpreter& interpreter,
-    mlir::MLIRContext& context) {
+    const std::string& argStr, mlir::Type argType, mlir::Interpreter& interpreter, mlir::MLIRContext& context
+) {
 
-  if (mlir::isa<mlir::IndexType>(argType)) {
-    intptr_t idx_val = std::stoll(argStr);
-    llvm::outs() << mli::fmt::dim("Parsing ")
-                 << mli::fmt::highlight(argStr) << mli::fmt::dim(" as ")
-                 << mli::fmt::type("index") << "\n";
-    return interpreter.createEvalValue(argType, &idx_val, sizeof(idx_val));
-  }
-  else if (mlir::isa<mlir::IntegerType>(argType)) {
-    unsigned width = argType.getIntOrFloatBitWidth();
-    APInt int_val = APInt(width, argStr, 10);
-    llvm::outs() << mli::fmt::dim("Parsing ")
-                << mli::fmt::highlight(argStr) << mli::fmt::dim(" as ")
-                << mli::fmt::type("i" + std::to_string(width)) << "\n";
-    return interpreter.createEvalValue(argType, &int_val, sizeof(int_val));
-  }
-  else if (mlir::isa<mlir::FloatType>(argType)) {
-    unsigned width = argType.getIntOrFloatBitWidth();
-    Semantics s = mli::getFloatSemantics(argType);
-    APFloat float_val = APFloat(APFloatBase::EnumToSemantics(s), argStr);
-    llvm::outs() << mli::fmt::dim("Parsing ")
-                << mli::fmt::highlight(argStr) << mli::fmt::dim(" as ")
-                << mli::fmt::type("f" + std::to_string(width)) << "\n";
-    return interpreter.createEvalValue(argType, &float_val, sizeof(float_val));
-  }
+    if ( mlir::isa<mlir::IndexType>(argType) ) {
+        intptr_t idx_val = std::stoll(argStr);
+        llvm::outs() << mli::fmt::dim("Parsing ") << mli::fmt::highlight(argStr) << mli::fmt::dim(" as ") << mli::fmt::type("index")
+                     << "\n";
+        return interpreter.createEvalValue(argType, &idx_val, sizeof(idx_val));
+    }
+    else if ( mlir::isa<mlir::IntegerType>(argType) ) {
+        unsigned width   = argType.getIntOrFloatBitWidth();
+        APInt    int_val = APInt(width, argStr, 10);
+        llvm::outs() << mli::fmt::dim("Parsing ") << mli::fmt::highlight(argStr) << mli::fmt::dim(" as ")
+                     << mli::fmt::type("i" + std::to_string(width)) << "\n";
+        return interpreter.createEvalValue(argType, &int_val, sizeof(int_val));
+    }
+    else if ( mlir::isa<mlir::FloatType>(argType) ) {
+        unsigned  width     = argType.getIntOrFloatBitWidth();
+        Semantics s         = mli::getFloatSemantics(argType);
+        APFloat   float_val = APFloat(APFloatBase::EnumToSemantics(s), argStr);
+        llvm::outs() << mli::fmt::dim("Parsing ") << mli::fmt::highlight(argStr) << mli::fmt::dim(" as ")
+                     << mli::fmt::type("f" + std::to_string(width)) << "\n";
+        return interpreter.createEvalValue(argType, &float_val, sizeof(float_val));
+    }
 
-  throw std::runtime_error("Unsupported argument type");
+    throw std::runtime_error("Unsupported argument type");
 }
 
 // Prepares arguments from command line for function execution
 static mlir::SmallVector<mlir::EvalValue, 4> prepareArguments(
-    mlir::func::FuncOp& func,
-    llvm::cl::list<std::string>& args,
-    mlir::Interpreter& interpreter,
-    mlir::MLIRContext& context) {
+    mlir::func::FuncOp& func, llvm::cl::list<std::string>& args, mlir::Interpreter& interpreter, mlir::MLIRContext& context
+) {
 
-  mlir::SmallVector<mlir::EvalValue, 4> functionArgs;
-  auto& entryBlock = func.getBody().front();
+    mlir::SmallVector<mlir::EvalValue, 4> functionArgs;
+    auto&                                 entryBlock = func.getBody().front();
 
-  // Convert command-line arguments to EvalValues
-  for (size_t i = 0; i < args.size(); ++i) {
-    auto arg_type = entryBlock.getArgument(i).getType();
+    // Convert command-line arguments to EvalValues
+    for ( size_t i = 0; i < args.size(); ++i ) {
+        auto arg_type = entryBlock.getArgument(i).getType();
 
-    try {
-      functionArgs.push_back(convertArgToEvalValue(args[i], arg_type, interpreter, context));
-    } catch (const std::exception& e) {
-      llvm::errs() << mli::fmt::error("Failed to parse argument '" + args[i] + "'") << "\n";
-      throw; // Re-throw to be caught by caller
+        try {
+            functionArgs.push_back(convertArgToEvalValue(args[i], arg_type, interpreter, context));
+        } catch ( const std::exception& e ) {
+            llvm::errs() << mli::fmt::error("Failed to parse argument '" + args[i] + "'") << "\n";
+            throw;  // Re-throw to be caught by caller
+        }
     }
-  }
 
-  return functionArgs;
+    return functionArgs;
 }
 
 // Represents a block to be executed with its arguments
 struct BlockExecution {
-  mlir::Block* block;
-  mlir::SmallVector<mlir::EvalValue, 4> args;
+    mlir::Block*                          block;
+    mlir::SmallVector<mlir::EvalValue, 4> args;
 };
 
 // Processes the result of a function execution for display
 static void processExecutionResult(const mlir::EvalResult& result) {
-  if (result.getKind() == mlir::EvalResultKind::ReturnValue) {
-    auto returnVals = result.getValues();
-    if (!returnVals.empty()) {
-      // Get the type
-      llvm::SmallVector<mlir::Type, 4> returnTypes;
-      for (const auto& val: returnVals) {
-        returnTypes.push_back(val.getType());
-      }
-      std::string typeStr = mli::printAsList(llvm::ArrayRef(returnTypes));
+    if ( result.getKind() == mlir::EvalResultKind::ReturnValue ) {
+        auto returnVals = result.getValues();
+        if ( !returnVals.empty() ) {
+            // Get the type
+            llvm::SmallVector<mlir::Type, 4> returnTypes;
+            for ( const auto& val : returnVals ) {
+                returnTypes.push_back(val.getType());
+            }
+            std::string typeStr  = mli::printAsList(llvm::ArrayRef(returnTypes));
 
-      // Format the value
-      std::string valueStr = mli::printAsList(returnVals);
+            // Format the value
+            std::string valueStr = mli::printAsList(returnVals);
 
-      llvm::outs() << mli::fmt::success("Function returned") << " "
-                  << mli::fmt::type(typeStr) << " = " << mli::fmt::highlight(valueStr) << "\n";
-    } else {
-      llvm::outs() << mli::fmt::success("Function completed") << " "
-                  << mli::fmt::type("void") << "\n";
+            llvm::outs() << mli::fmt::success("Function returned") << " " << mli::fmt::type(typeStr) << " = "
+                         << mli::fmt::highlight(valueStr) << "\n";
+        }
+        else {
+            llvm::outs() << mli::fmt::success("Function completed") << " " << mli::fmt::type("void") << "\n";
+        }
     }
-  } else {
-    // If we didn't get a ReturnValue, something unusual happened
-    llvm::errs() << mli::fmt::warning("Function execution completed without proper return")
-                << "\n";
-  }
+    else {
+        // If we didn't get a ReturnValue, something unusual happened
+        llvm::errs() << mli::fmt::warning("Function execution completed without proper return") << "\n";
+    }
 }
 
 // Executes a single operation and handles its result
-static std::pair<mlir::EvalResult, bool> executeOperation(
-    mlir::Operation& op,
-    mlir::Interpreter& interpreter,
-    std::vector<BlockExecution>& executionStack) {
+static std::pair<mlir::EvalResult, bool>
+    executeOperation(mlir::Operation& op, mlir::Interpreter& interpreter, std::vector<BlockExecution>& executionStack) {
 
-  // Get operands
-  llvm::SmallVector<mlir::EvalValue, 4> opOperands;
+    // Get operands
+    llvm::SmallVector<mlir::EvalValue, 4> opOperands;
 
-  for (auto operand : op.getOperands()) {
-    if (auto evalValue = interpreter.getEvalValue(operand)) {
-      opOperands.push_back(evalValue);
-    } else {
-      return {
-        interpreter.createErrorResult("Missing operand value for operation"),
-        true // hasCompleted
-      };
+    for ( auto operand : op.getOperands() ) {
+        if ( auto evalValue = interpreter.getEvalValue(operand) ) {
+            opOperands.push_back(evalValue);
+        }
+        else {
+            return {
+                interpreter.createErrorResult("Missing operand value for operation"),
+                true  // hasCompleted
+            };
+        }
     }
-  }
 
-  // Execute operation
-  mlir::EvalResult opResult = interpreter.execute(op, opOperands);
+    // Execute operation
+    mlir::EvalResult opResult = interpreter.execute(op, opOperands);
 
-  if (opResult.getKind() == mlir::EvalResultKind::Error) {
-    return {std::move(opResult), true}; // hasCompleted
-  }
-  else if (opResult.getKind() == mlir::EvalResultKind::ReturnValue ||
-           opResult.getKind() == mlir::EvalResultKind::YieldValue) {
-    return {std::move(opResult), true}; // hasCompleted
-  }
-  else if (opResult.getKind() == mlir::EvalResultKind::Branch) {
-    // Push the destination block onto our execution stack
-    if (opResult.getBlock()) {
-      executionStack.push_back({
-        opResult.getBlock(),
-        mlir::SmallVector<mlir::EvalValue, 4>(
-            opResult.getValues().begin(),
-            opResult.getValues().end())
-      });
-      return {mlir::EvalResult(), false}; // Signal continue with no final result yet
-    } else {
-      return {
-        interpreter.createErrorResult("Branch to null block"),
-        true // hasCompleted
-      };
+    if ( opResult.getKind() == mlir::EvalResultKind::Error ) {
+        return {std::move(opResult), true};  // hasCompleted
     }
-  }
-  else if (opResult.getKind() == mlir::EvalResultKind::BindValue) {
-    for (unsigned i = 0; i < op.getNumResults(); ++i) {
-      if (i < opResult.getValues().size()) {
-        interpreter.setEvalValue(op.getResult(i), opResult.getValues()[i]);
-      }
+    else if ( opResult.getKind() == mlir::EvalResultKind::ReturnValue || opResult.getKind() == mlir::EvalResultKind::YieldValue ) {
+        return {std::move(opResult), true};  // hasCompleted
     }
-    return {mlir::EvalResult(), false}; // Signal continue with no final result yet
-  }
+    else if ( opResult.getKind() == mlir::EvalResultKind::Branch ) {
+        // Push the destination block onto our execution stack
+        if ( opResult.getBlock() ) {
+            executionStack.push_back(
+                {opResult.getBlock(),
+                 mlir::SmallVector<mlir::EvalValue, 4>(opResult.getValues().begin(), opResult.getValues().end())}
+            );
+            return {mlir::EvalResult(), false};  // Signal continue with no final result yet
+        }
+        else {
+            return {
+                interpreter.createErrorResult("Branch to null block"),
+                true  // hasCompleted
+            };
+        }
+    }
+    else if ( opResult.getKind() == mlir::EvalResultKind::BindValue ) {
+        for ( unsigned i = 0; i < op.getNumResults(); ++i ) {
+            if ( i < opResult.getValues().size() ) {
+                interpreter.setEvalValue(op.getResult(i), opResult.getValues()[i]);
+            }
+        }
+        return {mlir::EvalResult(), false};  // Signal continue with no final result yet
+    }
 
-  // Default case
-  return {mlir::EvalResult(), false};
+    // Default case
+    return {mlir::EvalResult(), false};
 }
 
 // Executes a single block and returns the result
-static mlir::EvalResult executeBlock(
-    BlockExecution& blockExec,
-    mlir::Interpreter& interpreter,
-    std::vector<BlockExecution>& executionStack) {
+static mlir::EvalResult
+    executeBlock(BlockExecution& blockExec, mlir::Interpreter& interpreter, std::vector<BlockExecution>& executionStack) {
 
-  // Bind arguments
-  if (blockExec.block->getNumArguments() != blockExec.args.size()) {
-    return interpreter.createErrorResult(
-        "Block argument count mismatch: expected " +
-        std::to_string(blockExec.block->getNumArguments()) +
-        ", got " + std::to_string(blockExec.args.size()));
-  }
-
-  for (unsigned i = 0; i < blockExec.block->getNumArguments(); ++i) {
-    interpreter.setEvalValue(blockExec.block->getArgument(i), blockExec.args[i]);
-  }
-
-  // Execute operations
-  for (auto& op : *blockExec.block) {
-    auto [opResult, hasCompleted] = executeOperation(op, interpreter, executionStack);
-
-    if (hasCompleted) {
-      return std::move(opResult);
+    // Bind arguments
+    if ( blockExec.block->getNumArguments() != blockExec.args.size() ) {
+        return interpreter.createErrorResult(
+            "Block argument count mismatch: expected " + std::to_string(blockExec.block->getNumArguments()) + ", got " +
+            std::to_string(blockExec.args.size())
+        );
     }
 
-    // If not completed but we were told to stop this block, break out
-    if (!executionStack.empty() && executionStack.back().block != blockExec.block) {
-      break;
+    for ( unsigned i = 0; i < blockExec.block->getNumArguments(); ++i ) {
+        interpreter.setEvalValue(blockExec.block->getArgument(i), blockExec.args[i]);
     }
-  }
 
-  // If we reach here, the block ended without a terminator
-  return interpreter.createErrorResult("Block ended without terminator");
+    // Execute operations
+    for ( auto& op : *blockExec.block ) {
+        auto [opResult, hasCompleted] = executeOperation(op, interpreter, executionStack);
+
+        if ( hasCompleted ) {
+            return std::move(opResult);
+        }
+
+        // If not completed but we were told to stop this block, break out
+        if ( !executionStack.empty() && executionStack.back().block != blockExec.block ) {
+            break;
+        }
+    }
+
+    // If we reach here, the block ended without a terminator
+    return interpreter.createErrorResult("Block ended without terminator");
 }
 
 // Main entry point for executing a function
 static int executeFunction(
-    mlir::Interpreter& interpreter,
-    mlir::func::FuncOp func,
-    llvm::cl::list<std::string>& args,
-    mlir::MLIRContext& context) {
+    mlir::Interpreter& interpreter, mlir::func::FuncOp func, llvm::cl::list<std::string>& args, mlir::MLIRContext& context
+) {
 
-  try {
-    // Prepare arguments
-    mlir::SmallVector<mlir::EvalValue, 4> functionArgs =
-        prepareArguments(func, args, interpreter, context);
+    try {
+        // Prepare arguments
+        mlir::SmallVector<mlir::EvalValue, 4> functionArgs = prepareArguments(func, args, interpreter, context);
 
-    // Create scoped frames for execution
-    mlir::ScopedFunctionFrame functionFrame(interpreter);
-    mlir::ScopedRegionFrame regionFrame(interpreter);
+        // Create scoped frames for execution
+        mlir::ScopedFunctionFrame functionFrame(interpreter);
+        mlir::ScopedRegionFrame   regionFrame(interpreter);
 
-    // Setup execution stack
-    std::vector<BlockExecution> executionStack;
-    executionStack.push_back({&func.getBody().front(), functionArgs});
+        // Setup execution stack
+        std::vector<BlockExecution> executionStack;
+        executionStack.push_back({&func.getBody().front(), functionArgs});
 
-    mlir::EvalResult finalResult;
-    bool hasCompleted = false;
+        mlir::EvalResult finalResult;
+        bool             hasCompleted = false;
 
-    // Iterative execution loop
-    while (!executionStack.empty() && !hasCompleted) {
-      // Get the next block to execute
-      BlockExecution current = executionStack.back();
-      executionStack.pop_back();
+        // Iterative execution loop
+        while ( !executionStack.empty() && !hasCompleted ) {
+            // Get the next block to execute
+            BlockExecution current = executionStack.back();
+            executionStack.pop_back();
 
-      // Execute the block
-      mlir::EvalResult blockResult = executeBlock(current, interpreter, executionStack);
+            // Execute the block
+            mlir::EvalResult blockResult = executeBlock(current, interpreter, executionStack);
 
-      // If the block execution returned a result, we're done
-      if (blockResult.getKind() != mlir::EvalResultKind::Error || executionStack.empty()) {
-        finalResult = std::move(blockResult);
-        hasCompleted = true;
-      }
+            // If the block execution returned a result, we're done
+            if ( blockResult.getKind() != mlir::EvalResultKind::Error || executionStack.empty() ) {
+                finalResult  = std::move(blockResult);
+                hasCompleted = true;
+            }
+        }
+
+        // Process errors
+        if ( finalResult.getKind() == mlir::EvalResultKind::Error ) {
+            llvm::errs() << mli::fmt::error("Error in function execution: " + finalResult.getError().getMessage()) << "\n";
+            return 1;
+        }
+
+        // Process the final result for display
+        processExecutionResult(finalResult);
+
+        return 0;
+
+    } catch ( const std::exception& e ) {
+        // Handle any exceptions from argument parsing or other issues
+        llvm::errs() << mli::fmt::error(std::string("Exception during function execution: ") + e.what()) << "\n";
+        return 1;
     }
-
-    // Process errors
-    if (finalResult.getKind() == mlir::EvalResultKind::Error) {
-      llvm::errs() << mli::fmt::error("Error in function execution: " +
-                                    finalResult.getError().getMessage()) << "\n";
-      return 1;
-    }
-
-    // Process the final result for display
-    processExecutionResult(finalResult);
-
-    return 0;
-
-  } catch (const std::exception& e) {
-    // Handle any exceptions from argument parsing or other issues
-    llvm::errs() << mli::fmt::error(std::string("Exception during function execution: ") + e.what()) << "\n";
-    return 1;
-  }
 }
-
-

--- a/include/MLIFormat.h
+++ b/include/MLIFormat.h
@@ -1,6 +1,6 @@
 //===- MLIFormat.h - Multi-Level Interpreter Formatting Utils --*- C++ -*-===//
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,29 +19,29 @@
 #ifndef MLI_FORMAT_H
 #define MLI_FORMAT_H
 
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/Support/raw_ostream.h"
 #include <iostream>
 #include <string>
 #include <utility>
-#include "llvm/ADT/APInt.h"
-#include "llvm/ADT/APFloat.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace mli {
 namespace fmt {
 
 // "Specialize" std::to_string for common types that don't natively support it
-template <typename T>
+template<typename T>
 inline std::string to_string(T& val, bool isSigned = true) {
     std::string output;
     using stripped_type = std::remove_cv_t<T>;
-    if constexpr(std::is_same_v<stripped_type, llvm::APInt> || std::is_same_v<stripped_type, llvm::APSInt>) {
+    if constexpr ( std::is_same_v<stripped_type, llvm::APInt> || std::is_same_v<stripped_type, llvm::APSInt> ) {
         llvm::raw_string_ostream os(output);
         // The shovel operator for APInt automatically assumes the integer is signed
         // Use print instead to account for potential unsignedness
         val.print(os, isSigned);
         return os.str();
     }
-    else if constexpr(std::is_same_v<stripped_type, llvm::APFloat>) {
+    else if constexpr ( std::is_same_v<stripped_type, llvm::APFloat> ) {
         llvm::raw_string_ostream os(output);
         val.print(os);
         return os.str();
@@ -53,21 +53,21 @@ inline std::string to_string(T& val, bool isSigned = true) {
 
 // Specialization for std::pair
 // We could add this to the above, but that would require more trickery for the type comparison
-template <typename T1, typename T2>
+template<typename T1, typename T2>
 inline std::string to_string(const std::pair<T1, T2>& p, bool isSigned = true) {
     return "(" + to_string(p.first, isSigned) + ", " + to_string(p.second, isSigned) + ")";
 }
 
-inline bool usePrettyPrint = true;
+inline bool usePrettyPrint         = true;
 
 // ANSI escape codes for colors
-inline const char* const RED     = "\033[31m";
-inline const char* const GREEN   = "\033[32m";
-inline const char* const YELLOW  = "\033[33m";
-inline const char* const BLUE    = "\033[34m";
-inline const char* const MAGENTA = "\033[35m";
-inline const char* const CYAN    = "\033[36m";
-inline const char* const WHITE   = "\033[37m";
+inline const char* const RED       = "\033[31m";
+inline const char* const GREEN     = "\033[32m";
+inline const char* const YELLOW    = "\033[33m";
+inline const char* const BLUE      = "\033[34m";
+inline const char* const MAGENTA   = "\033[35m";
+inline const char* const CYAN      = "\033[36m";
+inline const char* const WHITE     = "\033[37m";
 
 // Text formatting
 inline const char* const BOLD      = "\033[1m";
@@ -78,70 +78,70 @@ inline const char* const RESET     = "\033[0m";
 
 // Utility functions for common formatting patterns
 inline std::string error(const std::string& msg) {
-    if (usePrettyPrint) {
+    if ( usePrettyPrint ) {
         return std::string(BOLD) + RED + "error" + RESET + ": " + msg;
     }
     return "error: " + msg;
 }
 
 inline std::string warning(const std::string& msg) {
-    if (usePrettyPrint) {
+    if ( usePrettyPrint ) {
         return std::string(BOLD) + YELLOW + "warning" + RESET + ": " + msg;
     }
     return "warning: " + msg;
 }
 
 inline std::string success(const std::string& msg) {
-    if (usePrettyPrint) {
+    if ( usePrettyPrint ) {
         return std::string(BOLD) + GREEN + "success" + RESET + ": " + msg;
     }
     return "success: " + msg;
 }
 
 inline std::string info(const std::string& msg) {
-    if (usePrettyPrint) {
+    if ( usePrettyPrint ) {
         return std::string(BOLD) + BLUE + "info" + RESET + ": " + msg;
     }
     return "info: " + msg;
 }
 
 inline std::string highlight(const std::string& msg) {
-    if (usePrettyPrint) {
+    if ( usePrettyPrint ) {
         return std::string(BOLD) + CYAN + msg + RESET;
     }
     return msg;
 }
 
 inline std::string dim(const std::string& msg) {
-    if (usePrettyPrint) {
+    if ( usePrettyPrint ) {
         return std::string(DIM) + msg + RESET;
     }
     return msg;
 }
 
 inline std::string type(const std::string& msg) {
-    if (usePrettyPrint) {
+    if ( usePrettyPrint ) {
         return std::string(MAGENTA) + msg + RESET;
     }
     return msg;
 }
 
 // Helper functions for operation output formatting
-inline void printOpName(llvm::raw_ostream &os, const std::string &opName) {
-  os << info("Interpreting " + opName) << "\n";
+inline void printOpName(llvm::raw_ostream& os, const std::string& opName) {
+    os << info("Interpreting " + opName) << "\n";
 }
 
 template<typename T>
-inline void printOperand(llvm::raw_ostream &os, const std::string &name, const T &value, bool isSigned = true) {
-  os << dim(name + ": ") << to_string(value, isSigned) << "\n";
+inline void printOperand(llvm::raw_ostream& os, const std::string& name, const T& value, bool isSigned = true) {
+    os << dim(name + ": ") << to_string(value, isSigned) << "\n";
 }
 
 template<typename T>
-inline void printResult(llvm::raw_ostream &os, const T &result, bool isSigned = true) {
-  os << dim("result: ") << to_string(result, isSigned) << "\n";
+inline void printResult(llvm::raw_ostream& os, const T& result, bool isSigned = true) {
+    os << dim("result: ") << to_string(result, isSigned) << "\n";
 }
 
-} // namespace fmt
-} // namespace mli
+}  // namespace fmt
+}  // namespace mli
 
-#endif // MLI_FORMAT_H
+#endif  // MLI_FORMAT_H

--- a/include/MLIUtils.h
+++ b/include/MLIUtils.h
@@ -20,18 +20,18 @@
 #define MLI_UTILS_H
 
 #include "MLIFormat.h"
-#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Bytecode/BytecodeReader.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Interpreter/InterpreterOpInterface.h"
 #include "mlir/Parser/Parser.h"
-#include "mlir/Bytecode/BytecodeReader.h"
 #include "mlir/Support/FileUtilities.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/APFloat.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 using Semantics = APFloatBase::Semantics;
@@ -39,201 +39,192 @@ using Semantics = APFloatBase::Semantics;
 namespace mli {
 
 /// Parse an MLIR file, detecting and handling both bytecode and text formats.
-inline mlir::OwningOpRef<mlir::ModuleOp> parseMLIRFile(llvm::StringRef filename,
-                                                       mlir::MLIRContext &context) {
-  // Open the input file.
-  std::string errorMessage;
-  auto file = mlir::openInputFile(filename, &errorMessage);
-  if (!file) {
-    llvm::errs() << mli::fmt::error(errorMessage) << "\n";
+inline mlir::OwningOpRef<mlir::ModuleOp> parseMLIRFile(llvm::StringRef filename, mlir::MLIRContext& context) {
+    // Open the input file.
+    std::string errorMessage;
+    auto        file = mlir::openInputFile(filename, &errorMessage);
+    if ( !file ) {
+        llvm::errs() << mli::fmt::error(errorMessage) << "\n";
+        return nullptr;
+    }
+
+    // Create a source manager for the input file.
+    llvm::SourceMgr sourceMgr;
+    sourceMgr.AddNewSourceBuffer(std::move(file), llvm::SMLoc());
+
+    // Create parser config.
+    mlir::ParserConfig config(&context);
+
+    // Attempt to parse the file (text or bytecode).
+    if ( auto owning_module = mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, config) ) {
+        llvm::outs() << mli::fmt::success("Parsed MLIR file: ") << filename << "\n";
+        return owning_module;
+    }
+
+    llvm::errs() << mli::fmt::error("Failed to parse MLIR file") << filename << "\n";
     return nullptr;
-  }
-
-  // Create a source manager for the input file.
-  llvm::SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(file), llvm::SMLoc());
-
-  // Create parser config.
-  mlir::ParserConfig config(&context);
-
-  // Attempt to parse the file (text or bytecode).
-  if (auto owning_module = mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, config)) {
-    llvm::outs() << mli::fmt::success("Parsed MLIR file: ") << filename << "\n";
-    return owning_module;
-  }
-
-  llvm::errs() << mli::fmt::error("Failed to parse MLIR file") << filename << "\n";
-  return nullptr;
 }
 
 /// Print a function's signature to the provided output stream.
-inline void printFunctionSignature(mlir::func::FuncOp funcOp, llvm::raw_ostream &os) {
-  os << mli::fmt::dim("Function '") << mli::fmt::highlight(funcOp.getName().str())
-     << mli::fmt::dim("' signature:") << "\n";
-  os << "  " << mli::fmt::highlight(funcOp.getName().str()) << "(";
-  
-  mlir::FunctionType fnType = funcOp.getFunctionType();
-  for (size_t i = 0; i < fnType.getNumInputs(); ++i) {
-    if (i > 0)
-      os << ", ";
-    std::string typeStr;
-    llvm::raw_string_ostream typeOs(typeStr);
-    fnType.getInput(i).print(typeOs);
-    os << mli::fmt::type(typeStr);
-  }
-  os << ") -> ";
-  
-  if (fnType.getNumResults() == 0) {
-    os << mli::fmt::type("void");
-  } else {
-    for (size_t i = 0; i < fnType.getNumResults(); ++i) {
-      if (i > 0)
-        os << ", ";
-      std::string typeStr;
-      llvm::raw_string_ostream typeOs(typeStr);
-      fnType.getResult(i).print(typeOs);
-      os << mli::fmt::type(typeStr);
+inline void printFunctionSignature(mlir::func::FuncOp funcOp, llvm::raw_ostream& os) {
+    os << mli::fmt::dim("Function '") << mli::fmt::highlight(funcOp.getName().str()) << mli::fmt::dim("' signature:") << "\n";
+    os << "  " << mli::fmt::highlight(funcOp.getName().str()) << "(";
+
+    mlir::FunctionType fnType = funcOp.getFunctionType();
+    for ( size_t i = 0; i < fnType.getNumInputs(); ++i ) {
+        if ( i > 0 )
+            os << ", ";
+        std::string              typeStr;
+        llvm::raw_string_ostream typeOs(typeStr);
+        fnType.getInput(i).print(typeOs);
+        os << mli::fmt::type(typeStr);
     }
-  }
-  os << "\n";
+    os << ") -> ";
+
+    if ( fnType.getNumResults() == 0 ) {
+        os << mli::fmt::type("void");
+    }
+    else {
+        for ( size_t i = 0; i < fnType.getNumResults(); ++i ) {
+            if ( i > 0 )
+                os << ", ";
+            std::string              typeStr;
+            llvm::raw_string_ostream typeOs(typeStr);
+            fnType.getResult(i).print(typeOs);
+            os << mli::fmt::type(typeStr);
+        }
+    }
+    os << "\n";
 }
 
 /// Validate function arguments against its signature.
 /// Returns true if the provided arguments match the expected function signature.
 /// In case of a mismatch, `errorMessage` is set accordingly.
-inline bool validateFunctionArguments(mlir::func::FuncOp funcOp, 
-                                        llvm::ArrayRef<int32_t> providedArgs,
-                                        std::string &errorMessage) {
-  // Get function type.
-  mlir::FunctionType fnType = funcOp.getFunctionType();
-  
-  std::string signature;
-  llvm::raw_string_ostream os(signature);
-  printFunctionSignature(funcOp, os);
-  
-  // Check number of arguments.
-  if (fnType.getNumInputs() != providedArgs.size()) {
-    errorMessage = mli::fmt::error("Argument count mismatch") + "\n" +
-                   signature +
-                   mli::fmt::dim("Provided ") + mli::fmt::highlight(std::to_string(providedArgs.size())) +
-                   mli::fmt::dim(" argument(s): [");
+inline bool validateFunctionArguments(mlir::func::FuncOp funcOp, llvm::ArrayRef<int32_t> providedArgs, std::string& errorMessage) {
+    // Get function type.
+    mlir::FunctionType fnType = funcOp.getFunctionType();
 
-    // Print provided arguments with their inferred type.
-    for (size_t i = 0; i < providedArgs.size(); ++i) {
-      if (i > 0)
-          errorMessage += ", ";
-      errorMessage += mli::fmt::highlight(std::to_string(providedArgs[i]));
-    }
-    errorMessage += mli::fmt::dim("] -> ") + mli::fmt::type("i32") + "\n" +
-                    mli::fmt::dim("Expected ") + mli::fmt::highlight(std::to_string(fnType.getNumInputs())) +
-                    mli::fmt::dim(" argument(s)");
-    return false;
-  }
+    std::string              signature;
+    llvm::raw_string_ostream os(signature);
+    printFunctionSignature(funcOp, os);
 
-  // Check argument types.
-  for (size_t i = 0; i < fnType.getNumInputs(); ++i) {
-    mlir::Type argType = fnType.getInput(i);
-    // TODO: implement floating point types.
-    if (!mlir::isa<mlir::IntegerType>(argType)) {
-      errorMessage = mli::fmt::error("Type mismatch for argument " + std::to_string(i)) + "\n" +
-                     signature +
-                     mli::fmt::dim("Provided value: ") + mli::fmt::highlight(std::to_string(providedArgs[i])) +
-                     mli::fmt::dim(" -> ") + mli::fmt::type("i32") + "\n" +
-                     mli::fmt::dim("Expected type: ") +
-                     mli::fmt::type(std::to_string(mlir::cast<mlir::IntegerType>(argType).getWidth()) + "-bit integer");
-      return false;
+    // Check number of arguments.
+    if ( fnType.getNumInputs() != providedArgs.size() ) {
+        errorMessage = mli::fmt::error("Argument count mismatch") + "\n" + signature + mli::fmt::dim("Provided ") +
+                       mli::fmt::highlight(std::to_string(providedArgs.size())) + mli::fmt::dim(" argument(s): [");
+
+        // Print provided arguments with their inferred type.
+        for ( size_t i = 0; i < providedArgs.size(); ++i ) {
+            if ( i > 0 )
+                errorMessage += ", ";
+            errorMessage += mli::fmt::highlight(std::to_string(providedArgs[i]));
+        }
+        errorMessage += mli::fmt::dim("] -> ") + mli::fmt::type("i32") + "\n" + mli::fmt::dim("Expected ") +
+                        mli::fmt::highlight(std::to_string(fnType.getNumInputs())) + mli::fmt::dim(" argument(s)");
+        return false;
     }
 
-    // Check integer width matches our int32_t.
-    auto intType = mlir::cast<mlir::IntegerType>(argType);
-    if (intType.getWidth() != 32) {
-      errorMessage = mli::fmt::error("Integer width mismatch for argument " + std::to_string(i)) + "\n" +
-                     signature +
-                     mli::fmt::dim("Provided value: ") + mli::fmt::highlight(std::to_string(providedArgs[i])) +
-                     mli::fmt::dim(" -> ") + mli::fmt::type("i32") + "\n" +
-                     mli::fmt::dim("Expected: ") +
-                     mli::fmt::type(std::to_string(intType.getWidth()) + "-bit integer");
-      return false;
+    // Check argument types.
+    for ( size_t i = 0; i < fnType.getNumInputs(); ++i ) {
+        mlir::Type argType = fnType.getInput(i);
+        // TODO: implement floating point types.
+        if ( !mlir::isa<mlir::IntegerType>(argType) ) {
+            errorMessage = mli::fmt::error("Type mismatch for argument " + std::to_string(i)) + "\n" + signature +
+                           mli::fmt::dim("Provided value: ") + mli::fmt::highlight(std::to_string(providedArgs[i])) +
+                           mli::fmt::dim(" -> ") + mli::fmt::type("i32") + "\n" + mli::fmt::dim("Expected type: ") +
+                           mli::fmt::type(std::to_string(mlir::cast<mlir::IntegerType>(argType).getWidth()) + "-bit integer");
+            return false;
+        }
+
+        // Check integer width matches our int32_t.
+        auto intType = mlir::cast<mlir::IntegerType>(argType);
+        if ( intType.getWidth() != 32 ) {
+            errorMessage = mli::fmt::error("Integer width mismatch for argument " + std::to_string(i)) + "\n" + signature +
+                           mli::fmt::dim("Provided value: ") + mli::fmt::highlight(std::to_string(providedArgs[i])) +
+                           mli::fmt::dim(" -> ") + mli::fmt::type("i32") + "\n" + mli::fmt::dim("Expected: ") +
+                           mli::fmt::type(std::to_string(intType.getWidth()) + "-bit integer");
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
 /// Get integer data from an mlir::EvalValue.
 inline APInt getIntegerData(const mlir::EvalValue& val, bool isSigned = false) {
-  return val.getData<APInt>().front();
+    return val.getData<APInt>().front();
 }
 
 /// Get float data from an mlir::EvalValue.
 inline APFloat getFloatData(const mlir::EvalValue& val) {
-  return val.getData<APFloat>().front();
+    return val.getData<APFloat>().front();
 }
 
 /// Get semantics for a given MLIR type.
 /// These semantics are used in constructing/converting APFloat types.
 inline Semantics getFloatSemantics(const mlir::Type& result_type) {
-  if (result_type.isF16()) { // 16-bit float.
-    return Semantics::S_IEEEhalf;
-  } else if (result_type.isBF16()) { // 16-bit brain float.
-    return Semantics::S_BFloat;
-  } else if (result_type.isF32()) { // Standard 32-bit float.
-    return Semantics::S_IEEEsingle;
-  }
-  return Semantics::S_IEEEdouble;
+    if ( result_type.isF16() ) {  // 16-bit float.
+        return Semantics::S_IEEEhalf;
+    }
+    else if ( result_type.isBF16() ) {  // 16-bit brain float.
+        return Semantics::S_BFloat;
+    }
+    else if ( result_type.isF32() ) {  // Standard 32-bit float.
+        return Semantics::S_IEEEsingle;
+    }
+    return Semantics::S_IEEEdouble;
 }
 
 /// Compute a unary floating point operation (e.g. std::sqrt, std::cos).
 /// The result will maintain the original number's semantics.
-inline APFloat compute(const APFloat &num, double (*func)(double)) {
-  double tmp = num.convertToDouble();
-  tmp = func(tmp);
-  APFloat result = APFloat(tmp);
-  bool losesInfo;
-  result.convert(num.getSemantics(), llvm::RoundingMode::TowardZero, &losesInfo);
-  return result;
+inline APFloat compute(const APFloat& num, double (*func)(double)) {
+    double tmp     = num.convertToDouble();
+    tmp            = func(tmp);
+    APFloat result = APFloat(tmp);
+    bool    losesInfo;
+    result.convert(num.getSemantics(), llvm::RoundingMode::TowardZero, &losesInfo);
+    return result;
 }
 
 /// Compute a binary floating point operation (e.g. std::pow, std::fmax)
 /// on two floats, converting them to double for computation.
-inline APFloat compute(const APFloat &lhs, const APFloat &rhs,
-                              double (*func)(double, double)) {
-  double tmp1 = lhs.convertToDouble();
-  double tmp2 = rhs.convertToDouble();
-  tmp1 = func(tmp1, tmp2);
-  APFloat result = APFloat(tmp1);
-  bool losesInfo;
-  result.convert(lhs.getSemantics(), llvm::RoundingMode::TowardZero, &losesInfo);
-  return result;
+inline APFloat compute(const APFloat& lhs, const APFloat& rhs, double (*func)(double, double)) {
+    double tmp1    = lhs.convertToDouble();
+    double tmp2    = rhs.convertToDouble();
+    tmp1           = func(tmp1, tmp2);
+    APFloat result = APFloat(tmp1);
+    bool    losesInfo;
+    result.convert(lhs.getSemantics(), llvm::RoundingMode::TowardZero, &losesInfo);
+    return result;
 }
 
 /// Compute a binary operation (e.g. std::powi) between a float and an integer.
 /// The float is converted to double for computation.
-inline APFloat compute(const APFloat &lhs, const APInt &rhs,
-                              double (*func)(double, int64_t)) {
-  double tmp1 = lhs.convertToDouble();
-  int64_t tmp2 = rhs.getSExtValue();
-  tmp1 = func(tmp1, tmp2);
-  APFloat result = APFloat(tmp1);
-  bool losesInfo;
-  result.convert(lhs.getSemantics(), llvm::RoundingMode::TowardZero, &losesInfo);
-  return result;
+inline APFloat compute(const APFloat& lhs, const APInt& rhs, double (*func)(double, int64_t)) {
+    double  tmp1   = lhs.convertToDouble();
+    int64_t tmp2   = rhs.getSExtValue();
+    tmp1           = func(tmp1, tmp2);
+    APFloat result = APFloat(tmp1);
+    bool    losesInfo;
+    result.convert(lhs.getSemantics(), llvm::RoundingMode::TowardZero, &losesInfo);
+    return result;
 }
 
 /// Get iterable represented as a comma-separated list
-template <typename T>
+template<typename T>
 inline std::string printAsList(const llvm::ArrayRef<T> arr) {
-    std::string output = arr.size() > 1 ? "(" : "";
+    std::string              output = arr.size() > 1 ? "(" : "";
     llvm::raw_string_ostream os(output);
-    for (auto it = arr.begin(); it != arr.end(); ++it) {
-        if (it != arr.begin()) os << ", ";
+    for ( auto it = arr.begin(); it != arr.end(); ++it ) {
+        if ( it != arr.begin() )
+            os << ", ";
         os << *it;
     }
-    if (arr.size() > 1) {
+    if ( arr.size() > 1 ) {
         os << ")";
     }
     return os.str();
 }
 
-} // namespace mli
+}  // namespace mli
 
-#endif // MLI_UTILS_H
+#endif  // MLI_UTILS_H

--- a/include/mlir/CMakeLists.txt
+++ b/include/mlir/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ===- include/mlir/CMakeLists.txt
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/include/mlir/Interpreter/CMakeLists.txt
+++ b/include/mlir/Interpreter/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ===- include/mlir/CMakeLists.txt
 #
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/include/mlir/Interpreter/Dialects/ArithInterpreter.h
+++ b/include/mlir/Interpreter/Dialects/ArithInterpreter.h
@@ -1,6 +1,6 @@
 //===- LLVMInterpreter.h - LLVM dialect interpreter -------------*- C++ -*-===//
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,20 +29,20 @@ namespace mlir {
 
 /// Dialect interpreter for the LLVM dialect.
 class ArithInterpreter {
-public:
-  using Dialect = arith::ArithDialect;
-  using Context = void;
+  public:
+    using Dialect = arith::ArithDialect;
+    using Context = void;
 
-  /// Attach the InterpreterOpInterface to the ops in the Func dialect.
-  static void attachInterface(MLIRContext &context);
+    /// Attach the InterpreterOpInterface to the ops in the Func dialect.
+    static void attachInterface(MLIRContext& context);
 
-  /// Create an interpreter context.
-  static Context *createContext() { return nullptr; }
+    /// Create an interpreter context.
+    static Context* createContext() { return nullptr; }
 
-  /// Destroy the interpreter context.
-  static void destroyContext(Context *) {}
+    /// Destroy the interpreter context.
+    static void destroyContext(Context*) {}
 };
 
-} // namespace mlir
+}  // namespace mlir
 
-#endif // MLIR_INTERPRETER_DIALECTS_ARITHINTERPRETER_H_
+#endif  // MLIR_INTERPRETER_DIALECTS_ARITHINTERPRETER_H_

--- a/include/mlir/Interpreter/Dialects/FuncInterpreter.h
+++ b/include/mlir/Interpreter/Dialects/FuncInterpreter.h
@@ -6,7 +6,7 @@
 //
 // The remaining portions of this file are:
 //
-// Copyright (C) 2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2024-2025 Tactical Computing Laboratories, LLC
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -31,20 +31,20 @@ namespace mlir {
 
 /// Dialect interpreter for the Func dialect.
 class FuncInterpreter {
-public:
-  using Dialect = func::FuncDialect;
-  using Context = void;
+  public:
+    using Dialect = func::FuncDialect;
+    using Context = void;
 
-  /// Attach the InterpreterOpInterface to the ops in the Func dialect.
-  static void attachInterface(MLIRContext &context);
+    /// Attach the InterpreterOpInterface to the ops in the Func dialect.
+    static void attachInterface(MLIRContext& context);
 
-  /// Create an interpreter context.
-  static Context *createContext() { return nullptr; }
+    /// Create an interpreter context.
+    static Context* createContext() { return nullptr; }
 
-  /// Destroy the interpreter context.
-  static void destroyContext(Context *) {}
+    /// Destroy the interpreter context.
+    static void destroyContext(Context*) {}
 };
 
-} // namespace mlir
+}  // namespace mlir
 
-#endif // MLIR_INTERPRETER_DIALECTS_FUNCINTERPRETER_H_
+#endif  // MLIR_INTERPRETER_DIALECTS_FUNCINTERPRETER_H_

--- a/include/mlir/Interpreter/Dialects/LLVMInterpreter.h
+++ b/include/mlir/Interpreter/Dialects/LLVMInterpreter.h
@@ -1,6 +1,6 @@
 //===- LLVMInterpreter.h - LLVM dialect interpreter -------------*- C++ -*-===//
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,20 +29,20 @@ namespace mlir {
 
 /// Dialect interpreter for the LLVM dialect.
 class LLVMInterpreter {
-public:
-  using Dialect = LLVM::LLVMDialect;
-  using Context = void;
+  public:
+    using Dialect = LLVM::LLVMDialect;
+    using Context = void;
 
-  /// Attach the InterpreterOpInterface to the ops in the Func dialect.
-  static void attachInterface(MLIRContext &context);
+    /// Attach the InterpreterOpInterface to the ops in the Func dialect.
+    static void attachInterface(MLIRContext& context);
 
-  /// Create an interpreter context.
-  static Context *createContext() { return nullptr; }
+    /// Create an interpreter context.
+    static Context* createContext() { return nullptr; }
 
-  /// Destroy the interpreter context.
-  static void destroyContext(Context *) {}
+    /// Destroy the interpreter context.
+    static void destroyContext(Context*) {}
 };
 
-} // namespace mlir
+}  // namespace mlir
 
-#endif // MLIR_INTERPRETER_DIALECTS_LLVMINTERPRETER_H_
+#endif  // MLIR_INTERPRETER_DIALECTS_LLVMINTERPRETER_H_

--- a/include/mlir/Interpreter/Interpreter.h
+++ b/include/mlir/Interpreter/Interpreter.h
@@ -1,6 +1,6 @@
 //===- LLVMInterpreter.h - LLVM dialect interpreter -------------*- C++ -*-===//
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,333 +43,309 @@ namespace detail {
 
 // Owning pointer for type-erased dialect op interpreter context.
 class OwningDialectInterpreterContext {
-public:
-  OwningDialectInterpreterContext() : context(nullptr), deleter(nullptr) {}
-  OwningDialectInterpreterContext(void *context, void (*deleter)(void *))
-      : context(context), deleter(deleter) {}
-  OwningDialectInterpreterContext(OwningDialectInterpreterContext &&rhs)
-      : context(rhs.context), deleter(rhs.deleter) {
-    rhs.context = nullptr;
-    rhs.deleter = nullptr;
-  }
-  OwningDialectInterpreterContext &
-  operator=(OwningDialectInterpreterContext &&rhs) {
-    if (&rhs != this) {
-      context = rhs.context;
-      deleter = rhs.deleter;
-      rhs.context = nullptr;
-      rhs.deleter = nullptr;
+  public:
+    OwningDialectInterpreterContext() : context(nullptr), deleter(nullptr) {}
+
+    OwningDialectInterpreterContext(void* context, void (*deleter)(void*)) : context(context), deleter(deleter) {}
+
+    OwningDialectInterpreterContext(OwningDialectInterpreterContext&& rhs) : context(rhs.context), deleter(rhs.deleter) {
+        rhs.context = nullptr;
+        rhs.deleter = nullptr;
     }
-    return *this;
-  }
-  ~OwningDialectInterpreterContext() {
-    if (context) {
-      deleter(context);
+
+    OwningDialectInterpreterContext& operator=(OwningDialectInterpreterContext&& rhs) {
+        if ( &rhs != this ) {
+            context     = rhs.context;
+            deleter     = rhs.deleter;
+            rhs.context = nullptr;
+            rhs.deleter = nullptr;
+        }
+        return *this;
     }
-  }
 
-  void *get() const { return context; }
+    ~OwningDialectInterpreterContext() {
+        if ( context ) {
+            deleter(context);
+        }
+    }
 
-private:
-  void *context;
-  void (*deleter)(void *);
+    void* get() const { return context; }
 
-private:
-  OwningDialectInterpreterContext(const OwningDialectInterpreterContext &) =
-      delete;
-  OwningDialectInterpreterContext &
-  operator=(const OwningDialectInterpreterContext &rhs) = delete;
+  private:
+    void* context;
+    void (*deleter)(void*);
+
+  private:
+    OwningDialectInterpreterContext(const OwningDialectInterpreterContext&)                = delete;
+    OwningDialectInterpreterContext& operator=(const OwningDialectInterpreterContext& rhs) = delete;
 };
 
-} // namespace detail
-
+}  // namespace detail
 
 class Interpreter {
-public:
-  explicit Interpreter(MLIRContext &context,
-                       bool enableStackTraceOnError = false,
-                       std::unique_ptr<MemoryManager> MemManager = nullptr);
+  public:
+    explicit Interpreter(
+        MLIRContext& context, bool enableStackTraceOnError = false, std::unique_ptr<MemoryManager> MemManager = nullptr
+    );
 
-  //===--------------------------------------------------------------------===//
-  // Dialect interpreter registration
-  //===--------------------------------------------------------------------===//
+    //===--------------------------------------------------------------------===//
+    // Dialect interpreter registration
+    //===--------------------------------------------------------------------===//
 
-  /// Register a dialect op interpreter.
-  template <typename DialectInterpreter, typename... Args>
-  void registerDialectInterpreter(Args &&...args) {
-    using Dialect = typename DialectInterpreter::Dialect;
+    /// Register a dialect op interpreter.
+    template<typename DialectInterpreter, typename... Args>
+    void registerDialectInterpreter(Args&&... args) {
+        using Dialect = typename DialectInterpreter::Dialect;
 
-    // Register and load the dialect.
-    DialectRegistry dialects;
-    dialects.insert<Dialect>();
-    context->appendDialectRegistry(dialects);
-    context->loadDialect<Dialect>();
+        // Register and load the dialect.
+        DialectRegistry dialects;
+        dialects.insert<Dialect>();
+        context->appendDialectRegistry(dialects);
+        context->loadDialect<Dialect>();
 
-    DialectInterpreter interpreterInstance;
-    interpreterInstance.attachInterface(*context);
+        DialectInterpreter interpreterInstance;
+        interpreterInstance.attachInterface(*context);
 
-    // Create dialect contexts.
-    detail::OwningDialectInterpreterContext context(
-        DialectInterpreter::createContext(std::forward<Args>(args)...),
-        [](void *context) {
-          using Context = typename DialectInterpreter::Context;
-          DialectInterpreter::destroyContext(
-              reinterpret_cast<Context *>(context));
-        });
-    dialectContexts[Dialect::getDialectNamespace()] = std::move(context);
-  }
-
-  template <typename DialectInterpreter, typename OtherDialectInterpreter,
-            typename... MoreDialectInterpreters, typename... Args>
-  void registerDialectInterpreter(Args &&...args) {
-    registerDialectInterpreter<DialectInterpreter>();
-    registerDialectInterpreter<OtherDialectInterpreter,
-                               MoreDialectInterpreters...>(
-        std::forward<Args>(args)...);
-  }
-
-  /// Get the dialect interpreter context.
-  template <typename DialectInterpreter>
-  typename DialectInterpreter::Context *getDialectInterpreterContext() const {
-    using Dialect = typename DialectInterpreter::Dialect;
-    auto iter = dialectContexts.find(Dialect::getDialectNamespace());
-    if (iter == dialectContexts.end()) {
-      return nullptr;
+        // Create dialect contexts.
+        detail::OwningDialectInterpreterContext context(
+            DialectInterpreter::createContext(std::forward<Args>(args)...), [](void* context) {
+                using Context = typename DialectInterpreter::Context;
+                DialectInterpreter::destroyContext(reinterpret_cast<Context*>(context));
+            }
+        );
+        dialectContexts[Dialect::getDialectNamespace()] = std::move(context);
     }
-    return reinterpret_cast<typename DialectInterpreter::Context *>(
-        iter->second.get());
-  }
 
-  //===--------------------------------------------------------------------===//
-  // MLIRContext and Module accessors
-  //===--------------------------------------------------------------------===//
-
-  /// Get the MLIR context.
-  MLIRContext &getContext() { return *context; }
-
-  /// Get the ModuleOp.
-  ModuleOp getModule() { return module; }
-
-  /// Set the ModuleOp.
-  void setModule(ModuleOp newModule) { module = newModule; }
-
-  //===--------------------------------------------------------------------===//
-  // Execution functions
-  //===--------------------------------------------------------------------===//
-
-  /// Find the function by name and execute the function with the function
-  /// arguments.
-  EvalResult execute(StringRef entry_func_name, ArrayRef<EvalValue> arguments);
-
-  /// Execute a function with the function arguments.
-  EvalResult execute(func::FuncOp func, ArrayRef<EvalValue> arguments);
-
-  /// Function argument provider callback function.
-  ///
-  /// All `execute` methods for `func::FuncOp` (or function name) has a variant
-  /// that takes `ArgumentProviderRef`. These `execute` methods pass the
-  /// function argument types to `argument_provider` and use the returned values
-  /// as actual arguments. With this interface, the callers of `execute` don't
-  /// have to find the `func::FuncOp` and extract its argument types by
-  /// themselves.
-  using ArgumentProviderRef =
-      llvm::function_ref<EvalResult(Interpreter &, TypeRange)>;
-
-  /// Find the function by name and execute the function with the function
-  /// arguments from the argument provider.
-  EvalResult execute(StringRef entry_func_name,
-                     ArgumentProviderRef argument_provider);
-
-  /// Execute a function with the function arguments from the argument provider.
-  EvalResult execute(func::FuncOp func, ArgumentProviderRef argument_provider);
-
-  /// Execute a region with the block arguments of the entry block.
-  EvalResult execute(Region &region, ArrayRef<EvalValue> arguments);
-
-  /// Execute a block with the block arguments.
-  EvalResult execute(Block &block, ArrayRef<EvalValue> arguments);
-
-  /// Execute an operation (get the input operands from the
-  /// SSA-name-to-evaluated-value map).
-  EvalResult execute(Operation &operation);
-
-  /// Execute an operation with the input operands.
-  EvalResult execute(Operation &operation, ArrayRef<EvalValue> operands);
-
-  //===--------------------------------------------------------------------===//
-  // Interpreter frame management functions
-  //===--------------------------------------------------------------------===//
-
-  /// Push a function frame (SSA lookup only can search up to the function
-  /// frame. The callee must not refer the SSA defined by the caller.)
-  void pushFunctionFrame() {
-    evalValueMapStack.push_front(std::forward_list<EvalValueMap>());
-  }
-
-  /// Pop a function frame.
-  void popFunctionFrame() {
-    assert(!evalValueMapStack.empty() && "function frame must be available");
-    assert(evalValueMapStack.front().empty() &&
-           "all region frames must be popped");
-    evalValueMapStack.pop_front();
-  }
-
-  /// Push a region frame (SSA lookup can search the outer region frame up
-  /// until the function frame).
-  void pushRegionFrame() {
-    assert(!evalValueMapStack.empty() && "function frame must be available");
-    evalValueMapStack.front().push_front(EvalValueMap());
-  }
-
-  /// Pop a region frame.
-  void popRegionFrame() {
-    assert(!evalValueMapStack.empty() && "function frame must be available");
-    assert(!evalValueMapStack.front().empty() &&
-           "region frame must be available");
-    evalValueMapStack.front().pop_front();
-  }
-
-  /// Get the evaluated value of an SSA name.
-  EvalValue getEvalValue(Value ssaName) const {
-    assert(!evalValueMapStack.empty() && "function frame must be available");
-    for (auto stackIter = evalValueMapStack.front().begin();
-         stackIter != evalValueMapStack.front().end(); ++stackIter) {
-      auto iter = stackIter->find(ssaName);
-      if (iter != stackIter->end()) {
-        return iter->second;
-      }
+    template<typename DialectInterpreter, typename OtherDialectInterpreter, typename... MoreDialectInterpreters, typename... Args>
+    void registerDialectInterpreter(Args&&... args) {
+        registerDialectInterpreter<DialectInterpreter>();
+        registerDialectInterpreter<OtherDialectInterpreter, MoreDialectInterpreters...>(std::forward<Args>(args)...);
     }
-    return EvalValue();
-  }
 
-  /// Bind an SSA name to an evaluated value.
-  void setEvalValue(Value ssaName, EvalValue value) {
-    assert(!evalValueMapStack.empty() && "function frame must be available");
-    assert(!evalValueMapStack.front().empty() &&
-           "region frame must be available");
-    evalValueMapStack.front().front()[ssaName] = std::move(value);
-  }
+    /// Get the dialect interpreter context.
+    template<typename DialectInterpreter>
+    typename DialectInterpreter::Context* getDialectInterpreterContext() const {
+        using Dialect = typename DialectInterpreter::Dialect;
+        auto iter     = dialectContexts.find(Dialect::getDialectNamespace());
+        if ( iter == dialectContexts.end() ) {
+            return nullptr;
+        }
+        return reinterpret_cast<typename DialectInterpreter::Context*>(iter->second.get());
+    }
 
-  /// Bind SSA names to evaluated values. Returns failure if the number of the
-  /// SSA names and the number of the evaluated values mismatches.
-  LogicalResult setEvalValues(ValueRange ssaNames,
-                              ArrayRef<EvalValue> evalValues);
+    //===--------------------------------------------------------------------===//
+    // MLIRContext and Module accessors
+    //===--------------------------------------------------------------------===//
 
-  //===--------------------------------------------------------------------===//
-  // EvalResult functions
-  //===--------------------------------------------------------------------===//
+    /// Get the MLIR context.
+    MLIRContext& getContext() { return *context; }
 
-  /// Create an EvalResult for an error message.
-  EvalResult createErrorResult(StringRef errorMessage);
+    /// Get the ModuleOp.
+    ModuleOp getModule() { return module; }
 
-  /// Create an EvalResult to bind op results to values.
-  EvalResult createBindValueResult(ArrayRef<EvalValue> values) {
-    return EvalResult(EvalResultKind::BindValue, values, nullptr, nullptr);
-  }
+    /// Set the ModuleOp.
+    void setModule(ModuleOp newModule) { module = newModule; }
 
-  /// Create an EvalResult for returning values.
-  EvalResult createReturnValueResult(ArrayRef<EvalValue> values) {
-    return EvalResult(EvalResultKind::ReturnValue, values, nullptr, nullptr);
-  }
+    //===--------------------------------------------------------------------===//
+    // Execution functions
+    //===--------------------------------------------------------------------===//
 
-  /// Create an EvalResult for yielding values.
-  EvalResult createYieldValueResult(ArrayRef<EvalValue> values) {
-    return EvalResult(EvalResultKind::YieldValue, values, nullptr, nullptr);
-  }
+    /// Find the function by name and execute the function with the function
+    /// arguments.
+    EvalResult execute(StringRef entry_func_name, ArrayRef<EvalValue> arguments);
 
-  /// Create an EvalResult for branching to another block.
-  ///
-  /// Explanation:
-  /// br ^bb1(%1 : i32)
-  /// ^bb1(%arg1: i32):
-  ///   %2 = addi %arg1, %0 : i32
-  ///   ...
-  /// Explanation:
-  /// The br operation branches to the block ^bb1, passing %1 as an argument.
-  /// The interpreter would produce an EvalResultKind::Branch as it transitions to the new block with %1 as the block argument.
-  EvalResult createBranchResult(Block &destBlock, ArrayRef<EvalValue> values) {
-    return EvalResult(EvalResultKind::Branch, values, &destBlock, nullptr);
-  }
+    /// Execute a function with the function arguments.
+    EvalResult execute(func::FuncOp func, ArrayRef<EvalValue> arguments);
 
-  //===--------------------------------------------------------------------===//
-  // EvalValue functions
-  //===--------------------------------------------------------------------===//
+    /// Function argument provider callback function.
+    ///
+    /// All `execute` methods for `func::FuncOp` (or function name) has a variant
+    /// that takes `ArgumentProviderRef`. These `execute` methods pass the
+    /// function argument types to `argument_provider` and use the returned values
+    /// as actual arguments. With this interface, the callers of `execute` don't
+    /// have to find the `func::FuncOp` and extract its argument types by
+    /// themselves.
+    using ArgumentProviderRef = llvm::function_ref<EvalResult(Interpreter&, TypeRange)>;
 
-  /// Create an EvalValue with uninitialized data buffer.
-  EvalValue createEvalValue(Type type, size_t dataSizeInBytes);
+    /// Find the function by name and execute the function with the function
+    /// arguments from the argument provider.
+    EvalResult execute(StringRef entry_func_name, ArgumentProviderRef argument_provider);
 
-  /// Create an EvalValue and initialize with `data`.
-  EvalValue createEvalValue(Type type, const void *data,
-                            size_t dataSizeInBytes);
+    /// Execute a function with the function arguments from the argument provider.
+    EvalResult execute(func::FuncOp func, ArgumentProviderRef argument_provider);
 
-  /// Create an EvalValue and initialize with `data`.
-  template <typename T>
-  EvalValue createEvalValue(Type type, llvm::ArrayRef<T> data) {
-    return createEvalValue(type, reinterpret_cast<const char *>(data.data()),
-                           sizeof(T) * data.size());
-  }
+    /// Execute a region with the block arguments of the entry block.
+    EvalResult execute(Region& region, ArrayRef<EvalValue> arguments);
 
-  // TODO: Change to smart pointer
-  MemoryManager &getMemManager() { return *MemManager; }
-private:
-  /// Mapping from SSA names to evaluated value. This represents a value lookup
-  /// scope within a region.
-  using EvalValueMap = llvm::DenseMap<Value, EvalValue>;
+    /// Execute a block with the block arguments.
+    EvalResult execute(Block& block, ArrayRef<EvalValue> arguments);
 
-  /// Mapping from dialect names to their interpreter context.
-  using DialectInterpreterContextMap =
-      llvm::DenseMap<llvm::StringRef, detail::OwningDialectInterpreterContext>;
+    /// Execute an operation (get the input operands from the
+    /// SSA-name-to-evaluated-value map).
+    EvalResult execute(Operation& operation);
 
-  /// Mapping from dialect names to dialect interpreter contexts.
-  DialectInterpreterContextMap dialectContexts;
+    /// Execute an operation with the input operands.
+    EvalResult execute(Operation& operation, ArrayRef<EvalValue> operands);
 
-  /// MLIRContext for this interpreter.
-  MLIRContext *context;
+    //===--------------------------------------------------------------------===//
+    // Interpreter frame management functions
+    //===--------------------------------------------------------------------===//
 
-  /// ModuleOp being interpreted. Typically, the interpreter will search the
-  /// callee function within this module.
-  ModuleOp module;
+    /// Push a function frame (SSA lookup only can search up to the function
+    /// frame. The callee must not refer the SSA defined by the caller.)
+    void pushFunctionFrame() { evalValueMapStack.push_front(std::forward_list<EvalValueMap>()); }
 
-  /// Stack for the mappings from SSA name to evaluated value.
-  std::forward_list<std::forward_list<EvalValueMap>> evalValueMapStack;
+    /// Pop a function frame.
+    void popFunctionFrame() {
+        assert(!evalValueMapStack.empty() && "function frame must be available");
+        assert(evalValueMapStack.front().empty() && "all region frames must be popped");
+        evalValueMapStack.pop_front();
+    }
 
-  /// Whether the interpreter should include a stack trace in `EvalError`.
-  bool enableStackTraceOnError;
+    /// Push a region frame (SSA lookup can search the outer region frame up
+    /// until the function frame).
+    void pushRegionFrame() {
+        assert(!evalValueMapStack.empty() && "function frame must be available");
+        evalValueMapStack.front().push_front(EvalValueMap());
+    }
 
-private:
-  Interpreter(const Interpreter &) = delete;
-  Interpreter &operator=(const Interpreter &) = delete;
-  std::unique_ptr<MemoryManager> MemManager;
+    /// Pop a region frame.
+    void popRegionFrame() {
+        assert(!evalValueMapStack.empty() && "function frame must be available");
+        assert(!evalValueMapStack.front().empty() && "region frame must be available");
+        evalValueMapStack.front().pop_front();
+    }
+
+    /// Get the evaluated value of an SSA name.
+    EvalValue getEvalValue(Value ssaName) const {
+        assert(!evalValueMapStack.empty() && "function frame must be available");
+        for ( auto stackIter = evalValueMapStack.front().begin(); stackIter != evalValueMapStack.front().end(); ++stackIter ) {
+            auto iter = stackIter->find(ssaName);
+            if ( iter != stackIter->end() ) {
+                return iter->second;
+            }
+        }
+        return EvalValue();
+    }
+
+    /// Bind an SSA name to an evaluated value.
+    void setEvalValue(Value ssaName, EvalValue value) {
+        assert(!evalValueMapStack.empty() && "function frame must be available");
+        assert(!evalValueMapStack.front().empty() && "region frame must be available");
+        evalValueMapStack.front().front()[ssaName] = std::move(value);
+    }
+
+    /// Bind SSA names to evaluated values. Returns failure if the number of the
+    /// SSA names and the number of the evaluated values mismatches.
+    LogicalResult setEvalValues(ValueRange ssaNames, ArrayRef<EvalValue> evalValues);
+
+    //===--------------------------------------------------------------------===//
+    // EvalResult functions
+    //===--------------------------------------------------------------------===//
+
+    /// Create an EvalResult for an error message.
+    EvalResult createErrorResult(StringRef errorMessage);
+
+    /// Create an EvalResult to bind op results to values.
+    EvalResult createBindValueResult(ArrayRef<EvalValue> values) {
+        return EvalResult(EvalResultKind::BindValue, values, nullptr, nullptr);
+    }
+
+    /// Create an EvalResult for returning values.
+    EvalResult createReturnValueResult(ArrayRef<EvalValue> values) {
+        return EvalResult(EvalResultKind::ReturnValue, values, nullptr, nullptr);
+    }
+
+    /// Create an EvalResult for yielding values.
+    EvalResult createYieldValueResult(ArrayRef<EvalValue> values) {
+        return EvalResult(EvalResultKind::YieldValue, values, nullptr, nullptr);
+    }
+
+    /// Create an EvalResult for branching to another block.
+    ///
+    /// Explanation:
+    /// br ^bb1(%1 : i32)
+    /// ^bb1(%arg1: i32):
+    ///   %2 = addi %arg1, %0 : i32
+    ///   ...
+    /// Explanation:
+    /// The br operation branches to the block ^bb1, passing %1 as an argument.
+    /// The interpreter would produce an EvalResultKind::Branch as it transitions to the new block with %1 as the block argument.
+    EvalResult createBranchResult(Block& destBlock, ArrayRef<EvalValue> values) {
+        return EvalResult(EvalResultKind::Branch, values, &destBlock, nullptr);
+    }
+
+    //===--------------------------------------------------------------------===//
+    // EvalValue functions
+    //===--------------------------------------------------------------------===//
+
+    /// Create an EvalValue with uninitialized data buffer.
+    EvalValue createEvalValue(Type type, size_t dataSizeInBytes);
+
+    /// Create an EvalValue and initialize with `data`.
+    EvalValue createEvalValue(Type type, const void* data, size_t dataSizeInBytes);
+
+    /// Create an EvalValue and initialize with `data`.
+    template<typename T>
+    EvalValue createEvalValue(Type type, llvm::ArrayRef<T> data) {
+        return createEvalValue(type, reinterpret_cast<const char*>(data.data()), sizeof(T) * data.size());
+    }
+
+    // TODO: Change to smart pointer
+    MemoryManager& getMemManager() { return *MemManager; }
+
+  private:
+    /// Mapping from SSA names to evaluated value. This represents a value lookup
+    /// scope within a region.
+    using EvalValueMap                 = llvm::DenseMap<Value, EvalValue>;
+
+    /// Mapping from dialect names to their interpreter context.
+    using DialectInterpreterContextMap = llvm::DenseMap<llvm::StringRef, detail::OwningDialectInterpreterContext>;
+
+    /// Mapping from dialect names to dialect interpreter contexts.
+    DialectInterpreterContextMap dialectContexts;
+
+    /// MLIRContext for this interpreter.
+    MLIRContext* context;
+
+    /// ModuleOp being interpreted. Typically, the interpreter will search the
+    /// callee function within this module.
+    ModuleOp module;
+
+    /// Stack for the mappings from SSA name to evaluated value.
+    std::forward_list<std::forward_list<EvalValueMap>> evalValueMapStack;
+
+    /// Whether the interpreter should include a stack trace in `EvalError`.
+    bool enableStackTraceOnError;
+
+  private:
+    Interpreter(const Interpreter&)                              = delete;
+    Interpreter&                   operator=(const Interpreter&) = delete;
+    std::unique_ptr<MemoryManager> MemManager;
 };
 
 /// Helper class to push and pop a function frame in a C++ scope.
 class ScopedFunctionFrame {
-private:
-  Interpreter &interpreter;
+  private:
+    Interpreter& interpreter;
 
-public:
-  explicit ScopedFunctionFrame(Interpreter &interpreter)
-      : interpreter(interpreter) {
-    interpreter.pushFunctionFrame();
-  }
+  public:
+    explicit ScopedFunctionFrame(Interpreter& interpreter) : interpreter(interpreter) { interpreter.pushFunctionFrame(); }
 
-  ~ScopedFunctionFrame() { interpreter.popFunctionFrame(); }
+    ~ScopedFunctionFrame() { interpreter.popFunctionFrame(); }
 };
 
 /// Helper class to push and pop a region frame in a C++ scope.
 class ScopedRegionFrame {
-private:
-  Interpreter &interpreter;
+  private:
+    Interpreter& interpreter;
 
-public:
-  explicit ScopedRegionFrame(Interpreter &interpreter)
-      : interpreter(interpreter) {
-    interpreter.pushRegionFrame();
-  }
+  public:
+    explicit ScopedRegionFrame(Interpreter& interpreter) : interpreter(interpreter) { interpreter.pushRegionFrame(); }
 
-  ~ScopedRegionFrame() { interpreter.popRegionFrame(); }
+    ~ScopedRegionFrame() { interpreter.popRegionFrame(); }
 };
 
-} // namespace mlir
+}  // namespace mlir
 
-#endif // MLIR_INTERPRETER_INTERPRETER_H_
+#endif  // MLIR_INTERPRETER_INTERPRETER_H_

--- a/include/mlir/Interpreter/InterpreterOpInterface.h
+++ b/include/mlir/Interpreter/InterpreterOpInterface.h
@@ -14,15 +14,15 @@
 #ifndef MLIR_INTERFACES_INTERPRETEROPINTERFACE_H_
 #define MLIR_INTERFACES_INTERPRETEROPINTERFACE_H_
 
-#include "mlir/Dialect/Traits.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/Traits.h"
 #include "mlir/IR/OpDefinition.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/APInt.h"
-#include "llvm/ADT/APFloat.h"
 
 #include <memory>
 #include <string>
@@ -34,180 +34,170 @@ class Interpreter;
 
 namespace detail {
 class EvalValueImpl : public llvm::RefCountedBase<EvalValueImpl> {
-public:
-  constexpr static size_t kAlign = 8;
+  public:
+    constexpr static size_t kAlign = 8;
 
-public:
-  EvalValueImpl(Type type, size_t dataSize) : type(type), data(dataSize, 0) {}
+  public:
+    EvalValueImpl(Type type, size_t dataSize) : type(type), data(dataSize, 0) {}
 
-  EvalValueImpl(Type type, llvm::ArrayRef<char> data)
-      : type(type), data(data.begin(), data.end()) {}
+    EvalValueImpl(Type type, llvm::ArrayRef<char> data) : type(type), data(data.begin(), data.end()) {}
 
-  Type getType() const { return type; }
+    Type getType() const { return type; }
 
-  size_t getRawDataSizeInBytes() const { return data.size(); }
+    size_t getRawDataSizeInBytes() const { return data.size(); }
 
-  char *getRawData() { return data.data(); }
+    char* getRawData() { return data.data(); }
 
-  const char *getRawData() const { return data.data(); }
+    const char* getRawData() const { return data.data(); }
 
-private:
-  Type type;
-  std::vector<char> data;
+  private:
+    Type              type;
+    std::vector<char> data;
 };
-} // namespace detail
+}  // namespace detail
 
 /// A handle to the evaluated value.
 class EvalValue {
-private:
-  friend class Interpreter;
+  private:
+    friend class Interpreter;
 
-public:
-  EvalValue();
-  ~EvalValue();
-  EvalValue(const EvalValue &src);
-  EvalValue &operator=(const EvalValue &src);
-  EvalValue(EvalValue &&src);
-  EvalValue &operator=(EvalValue &&src);
+  public:
+    EvalValue();
+    ~EvalValue();
+    EvalValue(const EvalValue& src);
+    EvalValue& operator=(const EvalValue& src);
+    EvalValue(EvalValue&& src);
+    EvalValue& operator=(EvalValue&& src);
 
-private:
-  explicit EvalValue(detail::EvalValueImpl *impl);
-  friend llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const mlir::EvalValue& val);
+  private:
+    explicit EvalValue(detail::EvalValueImpl* impl);
+    friend llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const mlir::EvalValue& val);
 
-public:
-  /// Returns the type of the evaluated value.
-  Type getType() const;
+  public:
+    /// Returns the type of the evaluated value.
+    Type getType() const;
 
-  /// Returns the data buffer size for the evaluated value.
-  size_t getRawDataSizeInBytes() const;
+    /// Returns the data buffer size for the evaluated value.
+    size_t getRawDataSizeInBytes() const;
 
-  /// Returns the data buffer for the evaluated value.
-  char *getRawData();
+    /// Returns the data buffer for the evaluated value.
+    char* getRawData();
 
-  /// Returns the data buffer for the evaluated value.
-  const char *getRawData() const;
+    /// Returns the data buffer for the evaluated value.
+    const char* getRawData() const;
 
-  template <typename DataType>
-  llvm::MutableArrayRef<DataType> getData() {
-    size_t dataSizeInBytes = getRawDataSizeInBytes();
-    assert(dataSizeInBytes % sizeof(DataType) == 0);
-    return llvm::MutableArrayRef<DataType>(
-        reinterpret_cast<DataType *>(getRawData()),
-        dataSizeInBytes / sizeof(DataType));
-  }
+    template<typename DataType>
+    llvm::MutableArrayRef<DataType> getData() {
+        size_t dataSizeInBytes = getRawDataSizeInBytes();
+        assert(dataSizeInBytes % sizeof(DataType) == 0);
+        return llvm::MutableArrayRef<DataType>(reinterpret_cast<DataType*>(getRawData()), dataSizeInBytes / sizeof(DataType));
+    }
 
-  template <typename DataType>
-  llvm::ArrayRef<DataType> getData() const {
-    size_t dataSizeInBytes = getRawDataSizeInBytes();
-    assert(dataSizeInBytes % sizeof(DataType) == 0);
-    return llvm::ArrayRef<DataType>(
-        reinterpret_cast<const DataType *>(getRawData()),
-        dataSizeInBytes / sizeof(DataType));
-  }
+    template<typename DataType>
+    llvm::ArrayRef<DataType> getData() const {
+        size_t dataSizeInBytes = getRawDataSizeInBytes();
+        assert(dataSizeInBytes % sizeof(DataType) == 0);
+        return llvm::ArrayRef<DataType>(reinterpret_cast<const DataType*>(getRawData()), dataSizeInBytes / sizeof(DataType));
+    }
 
-  /// Returns whether this handle holds a null value.
-  explicit operator bool() const { return static_cast<bool>(impl); }
+    /// Returns whether this handle holds a null value.
+    explicit operator bool() const { return static_cast<bool>(impl); }
 
-  /// Checks whether `this` and `rhs` refer to the same value.
-  bool operator==(const EvalValue &rhs) const { return impl == rhs.impl; }
+    /// Checks whether `this` and `rhs` refer to the same value.
+    bool operator==(const EvalValue& rhs) const { return impl == rhs.impl; }
 
-  /// Checks whether `this` and `rhs` refer to different values.
-  bool operator!=(const EvalValue &rhs) const { return impl != rhs.impl; }
+    /// Checks whether `this` and `rhs` refer to different values.
+    bool operator!=(const EvalValue& rhs) const { return impl != rhs.impl; }
 
-private:
-  llvm::IntrusiveRefCntPtr<detail::EvalValueImpl> impl;
+  private:
+    llvm::IntrusiveRefCntPtr<detail::EvalValueImpl> impl;
 };
-
 
 /// A class to represent interpreter evaluation errors.
 class EvalError {
-public:
-  explicit EvalError(llvm::StringRef message,
-                     bool shouldPrintStackTrace = false);
+  public:
+    explicit EvalError(llvm::StringRef message, bool shouldPrintStackTrace = false);
 
-  /// Get the error message.
-  const std::string &getMessage() const { return message; }
+    /// Get the error message.
+    const std::string& getMessage() const { return message; }
 
-  /// Get the stack trace.
-  const std::string &getStackTrace() const { return stacktrace; }
+    /// Get the stack trace.
+    const std::string& getStackTrace() const { return stacktrace; }
 
-private:
-  std::string message;
-  std::string stacktrace;
+  private:
+    std::string message;
+    std::string stacktrace;
 };
 
 /// Evaluation result states.
 enum class EvalResultKind {
-  /// An error occurs in the interpreter. In this state, `getError()` returns
-  /// an `EvalError` object.
-  Error,
+    /// An error occurs in the interpreter. In this state, `getError()` returns
+    /// an `EvalError` object.
+    Error,
 
-  /// Bind evaluated values to the op result SSA names. In this state,
-  /// `getValues()` returns the evaluated values which should be bound to SSA
-  /// names.
-  BindValue,
+    /// Bind evaluated values to the op result SSA names. In this state,
+    /// `getValues()` returns the evaluated values which should be bound to SSA
+    /// names.
+    BindValue,
 
-  /// Return evaluated values to the caller. In this state, `getValues()`
-  /// returns the evaluated values which should be treated as the function
-  /// return values.
-  ///
-  /// Note: Typically, `ReturnValue` may pop multiple regions until it is
-  /// handled by a call op.
-  ReturnValue,
+    /// Return evaluated values to the caller. In this state, `getValues()`
+    /// returns the evaluated values which should be treated as the function
+    /// return values.
+    ///
+    /// Note: Typically, `ReturnValue` may pop multiple regions until it is
+    /// handled by a call op.
+    ReturnValue,
 
-  /// Return evaluated values to the parent op. In this state, `getValues()`
-  /// returns the evaluated values which should be treated as the region yield
-  /// values.
-  ///
-  /// Note: Typically, `YieldValue` only pops one region and will be handled by
-  /// the parent op.
-  YieldValue,
+    /// Return evaluated values to the parent op. In this state, `getValues()`
+    /// returns the evaluated values which should be treated as the region yield
+    /// values.
+    ///
+    /// Note: Typically, `YieldValue` only pops one region and will be handled by
+    /// the parent op.
+    YieldValue,
 
-  /// Branch to a new block. In this state, `getBlock()` returns the
-  /// destination block and `getValues()` returns the block arguments.
-  Branch,
+    /// Branch to a new block. In this state, `getBlock()` returns the
+    /// destination block and `getValues()` returns the block arguments.
+    Branch,
 };
 
 /// A class to represent the interpreter evaluation results.
 class EvalResult {
-  friend class Interpreter;
+    friend class Interpreter;
 
-public:
-  EvalResult() : kind(EvalResultKind::Error) {}
+  public:
+    EvalResult() : kind(EvalResultKind::Error) {}
 
-private:
-  EvalResult(EvalResultKind kind, llvm::ArrayRef<EvalValue> values,
-             Block *block, std::unique_ptr<EvalError> error)
-      : kind(kind), values(values.begin(), values.end()), block(block),
-        error(std::move(error)) {}
+  private:
+    EvalResult(EvalResultKind kind, llvm::ArrayRef<EvalValue> values, Block* block, std::unique_ptr<EvalError> error)
+        : kind(kind), values(values.begin(), values.end()), block(block), error(std::move(error)) {}
 
-public:
-  /// Get the evaluation result kind.
-  EvalResultKind getKind() const { return kind; }
+  public:
+    /// Get the evaluation result kind.
+    EvalResultKind getKind() const { return kind; }
 
-  /// Get the evaluated values for BindValue, ReturnValue, and YieldValue and
-  /// the block arguments for Branch.
-  llvm::ArrayRef<EvalValue> getValues() { return llvm::ArrayRef<EvalValue>(values); }
-  llvm::ArrayRef<EvalValue> getValues() const {
-    return llvm::ArrayRef<EvalValue>(values);
-  }
+    /// Get the evaluated values for BindValue, ReturnValue, and YieldValue and
+    /// the block arguments for Branch.
+    llvm::ArrayRef<EvalValue> getValues() { return llvm::ArrayRef<EvalValue>(values); }
 
-  /// Get the branch destination block.
-  Block *getBlock() const { return block; }
+    llvm::ArrayRef<EvalValue> getValues() const { return llvm::ArrayRef<EvalValue>(values); }
 
-  /// Get the evaluation error.
-  const EvalError &getError() const { return *error; }
+    /// Get the branch destination block.
+    Block* getBlock() const { return block; }
 
-private:
-  EvalResultKind kind;
-  llvm::SmallVector<EvalValue, 1> values;
-  Block *block;
-  std::unique_ptr<EvalError> error;
+    /// Get the evaluation error.
+    const EvalError& getError() const { return *error; }
+
+  private:
+    EvalResultKind                  kind;
+    llvm::SmallVector<EvalValue, 1> values;
+    Block*                          block;
+    std::unique_ptr<EvalError>      error;
 };
 
-} // namespace mlir
+}  // namespace mlir
 
 /// Include the generated interface declarations.
 #include "mlir/Interpreter/InterpreterOpInterface.h.inc"
 
-#endif // MLIR_INTERFACES_INTERPRETEROPINTERFACE_H_
+#endif  // MLIR_INTERFACES_INTERPRETEROPINTERFACE_H_

--- a/include/mlir/Interpreter/MemoryManager.h
+++ b/include/mlir/Interpreter/MemoryManager.h
@@ -1,6 +1,6 @@
-//===- MemoryManager.h 
+//===- MemoryManager.h
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,23 +19,23 @@
 #define MLIR_INTERPRETER_MEMORYMANAGER_H
 
 #include <algorithm>
-#include <list>
-#include <vector>
-#include <map>
 #include <cstdint>
-#include <string>
 #include <cstring>
+#include <list>
+#include <map>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
-namespace mlir{
+namespace mlir {
 
 class MemoryManager {
-public:
-  virtual ~MemoryManager() = default;
-  virtual uint64_t allocate(size_t size) = 0;
-  virtual void free(uint64_t addr) = 0;
-  virtual void read(uint64_t addr, void *dst, size_t size) = 0;
-  virtual void write(uint64_t addr, const void *src, size_t size) = 0;
+  public:
+    virtual ~MemoryManager()                                            = default;
+    virtual uint64_t allocate(size_t size)                              = 0;
+    virtual void     free(uint64_t addr)                                = 0;
+    virtual void     read(uint64_t addr, void* dst, size_t size)        = 0;
+    virtual void     write(uint64_t addr, const void* src, size_t size) = 0;
 };
 
 /// TODO: Move to another file maybe?
@@ -44,152 +44,150 @@ public:
 ///  - Returns a 64-bit "address" (offset into the buffer).
 ///  - Performs simple bounds checking on read/write.
 class SimpleMemoryManager : public MemoryManager {
-public:
-  explicit SimpleMemoryManager(size_t initialSize = 1024 * 1024) {
-    // Pre-allocate our contiguous memory space
-    Mem.resize(initialSize, 0);
-    freeBlocks = {std::make_pair(0, initialSize)};
-    next = freeBlocks.begin();
-  }
+  public:
+    explicit SimpleMemoryManager(size_t initialSize = 1024 * 1024) {
+        // Pre-allocate our contiguous memory space
+        Mem.resize(initialSize, 0);
+        freeBlocks = {std::make_pair(0, initialSize)};
+        next       = freeBlocks.begin();
+    }
 
-  /// Allocate 'size' bytes. We return an offset (uint64_t) into our single buffer.
-  /// Throws std::bad_alloc if we can’t fit the allocation.
-  uint64_t allocate(size_t size) override {
-    // Keep track of first examined block
-    auto oldNext = next;
-    do {
-        if (next->second >= size) {
-            // Current block is large enough for allocation
-            uint64_t addr = next->first;
-            Allocation allocInfo;
-            allocInfo.size = size;
-            allocations[addr] = allocInfo;
+    /// Allocate 'size' bytes. We return an offset (uint64_t) into our single buffer.
+    /// Throws std::bad_alloc if we can't fit the allocation.
+    uint64_t allocate(size_t size) override {
+        // Keep track of first examined block
+        auto oldNext = next;
+        do {
+            if ( next->second >= size ) {
+                // Current block is large enough for allocation
+                uint64_t   addr = next->first;
+                Allocation allocInfo;
+                allocInfo.size    = size;
+                allocations[addr] = allocInfo;
 
-            // Update block to reflect allocation
-            next->first += size;
-            next->second -= size;
-            return addr;
-        }
-        // Advance list, circling back if at end
-        next = ++next == freeBlocks.end() ? freeBlocks.begin() : next;
-    } while (next != oldNext);
-
-    // We've traversed all available blocks, and none are large enough
-    throw std::bad_alloc();
-  }
-
-  /// Remove allocation associated with addr from map
-  /// Also reclaims freed memory for future allocations
-  void free(uint64_t addr) override {
-    uint64_t freedSize = allocations[addr].size;
-    allocations.erase(addr);
-
-    // Consolidate blocks by reclaiming freed memory
-    // Find supremum/infimum of freed block located at addr
-    // (i.e. closest available blocks on either side of freed block)
-    auto right = std::upper_bound(freeBlocks.begin(), freeBlocks.end(), addr,
-        [](const uint64_t a, const std::pair<uint64_t, uint64_t>& b) {
-            return a < b.first;
-        }
-    );
-    auto left = std::prev(right);
-
-    // Test if the adjacent blocks of the freed block are available
-    // This determines how the blocks can be consolidated
-    bool openLeft = left->first+left->second == addr;
-    bool openRight = right->first == addr + freedSize;
-
-    if (openLeft && openRight) {
-        // Case I: Incorporate both the freed block and right into left
-        left->second += (freedSize + right->second);
-        // The right pointer is now redundant, so we can delete it
-        // Ensure that next != right to prevent dangling pointer
-        if (next == right) {
+                // Update block to reflect allocation
+                next->first += size;
+                next->second -= size;
+                return addr;
+            }
+            // Advance list, circling back if at end
             next = ++next == freeBlocks.end() ? freeBlocks.begin() : next;
+        } while ( next != oldNext );
+
+        // We've traversed all available blocks, and none are large enough
+        throw std::bad_alloc();
+    }
+
+    /// Remove allocation associated with addr from map
+    /// Also reclaims freed memory for future allocations
+    void free(uint64_t addr) override {
+        uint64_t freedSize = allocations[addr].size;
+        allocations.erase(addr);
+
+        // Consolidate blocks by reclaiming freed memory
+        // Find supremum/infimum of freed block located at addr
+        // (i.e. closest available blocks on either side of freed block)
+        auto right = std::upper_bound(
+            freeBlocks.begin(), freeBlocks.end(), addr, [](const uint64_t a, const std::pair<uint64_t, uint64_t>& b) {
+                return a < b.first;
+            }
+        );
+        auto left      = std::prev(right);
+
+        // Test if the adjacent blocks of the freed block are available
+        // This determines how the blocks can be consolidated
+        bool openLeft  = left->first + left->second == addr;
+        bool openRight = right->first == addr + freedSize;
+
+        if ( openLeft && openRight ) {
+            // Case I: Incorporate both the freed block and right into left
+            left->second += (freedSize + right->second);
+            // The right pointer is now redundant, so we can delete it
+            // Ensure that next != right to prevent dangling pointer
+            if ( next == right ) {
+                next = ++next == freeBlocks.end() ? freeBlocks.begin() : next;
+            }
+            freeBlocks.erase(right);  // made redundant by expansion
         }
-        freeBlocks.erase(right); // made redundant by expansion
+        else if ( openLeft && !openRight ) {
+            // Case II: Incorporate the freed block into left
+            left->second += freedSize;
+        }
+        else if ( !openLeft && openRight ) {
+            // Case III: Incorporate the freed block into right
+            right->first = addr;
+            right->second += freedSize;
+        }
+        else {
+            // Case IV: Bookended by allocated memory, create new entry between left and right
+            auto newBlock = std::make_pair(addr, freedSize);
+            freeBlocks.insert(right, newBlock);
+        }
     }
-    else if (openLeft && !openRight) {
-        // Case II: Incorporate the freed block into left
-        left->second += freedSize;
-    }
-    else if (!openLeft && openRight)  {
-        // Case III: Incorporate the freed block into right
-        right->first = addr;
-        right->second += freedSize;
-    }
-    else {
-        // Case IV: Bookended by allocated memory, create new entry between left and right
-        auto newBlock = std::make_pair(addr, freedSize);
-        freeBlocks.insert(right, newBlock);
+
+    /// Read 'size' bytes from address 'addr' into 'dst'.
+    /// Performs simple bounds checking against our recorded allocations.
+    void read(uint64_t addr, void* dst, size_t size) override {
+        auto [allocStart, allocInfo] = findAllocation(addr);
+        // Ensure the entire read fits within [allocStart, allocStart + allocSize)
+        if ( addr + size > allocStart + allocInfo.size )
+            throw std::runtime_error("SimpleMemoryManager: read out of bounds");
+
+        std::memcpy(dst, &Mem[addr], size);
     }
 
-  }
+    /// Write 'size' bytes from 'src' into address 'addr'.
+    /// Performs simple bounds checking.
+    void write(uint64_t addr, const void* src, size_t size) override {
+        auto [allocStart, allocInfo] = findAllocation(addr);
+        // Ensure the entire write fits within [allocStart, allocStart + allocSize)
+        if ( addr + size > allocStart + allocInfo.size )
+            throw std::runtime_error("SimpleMemoryManager: write out of bounds");
 
-  /// Read 'size' bytes from address 'addr' into 'dst'.
-  /// Performs simple bounds checking against our recorded allocations.
-  void read(uint64_t addr, void *dst, size_t size) override {
-    auto [allocStart, allocInfo] = findAllocation(addr);
-    // Ensure the entire read fits within [allocStart, allocStart + allocSize)
-    if (addr + size > allocStart + allocInfo.size)
-      throw std::runtime_error("SimpleMemoryManager: read out of bounds");
-
-    std::memcpy(dst, &Mem[addr], size);
-  }
-
-  /// Write 'size' bytes from 'src' into address 'addr'.
-  /// Performs simple bounds checking.
-  void write(uint64_t addr, const void *src, size_t size) override {
-    auto [allocStart, allocInfo] = findAllocation(addr);
-    // Ensure the entire write fits within [allocStart, allocStart + allocSize)
-    if (addr + size > allocStart + allocInfo.size)
-      throw std::runtime_error("SimpleMemoryManager: write out of bounds");
-
-    std::memcpy(&Mem[addr], src, size);
-  }
-
-private:
-  /// A struct to track basic allocation metadata.
-  /// TODO: Add alignment, original request, etc.
-  struct Allocation {
-    size_t size;
-  };
-
-  /// Lookup which allocation covers a given address 'addr'.
-  /// We do a lower_bound or predecessor search to find the earliest allocation
-  /// that starts before (or at) 'addr'.
-  std::pair<uint64_t, Allocation> findAllocation(uint64_t addr) {
-    // Upper bound returns the first iterator greater than 'addr'.
-    auto it = allocations.upper_bound(addr);
-    // If 'it' is not the first in the map, step back one to see if that
-    // allocation covers 'addr'.
-    if (it != allocations.begin()) {
-      --it;
-      uint64_t allocStart = it->first;
-      const Allocation &info = it->second;
-      if (addr >= allocStart && addr < (allocStart + info.size)) {
-        return {allocStart, info};
-      }
+        std::memcpy(&Mem[addr], src, size);
     }
-    throw std::runtime_error("SimpleMemoryManager: address not in any allocation");
-  }
 
-  // A single contiguous buffer
-  std::vector<char> Mem;
+  private:
+    /// A struct to track basic allocation metadata.
+    /// TODO: Add alignment, original request, etc.
+    struct Allocation {
+        size_t size;
+    };
 
-  // All available memory blocks, available as pairs [beginAddr, size]
-  std::list<std::pair<uint64_t, uint64_t>> freeBlocks;
+    /// Lookup which allocation covers a given address 'addr'.
+    /// We do a lower_bound or predecessor search to find the earliest allocation
+    /// that starts before (or at) 'addr'.
+    std::pair<uint64_t, Allocation> findAllocation(uint64_t addr) {
+        // Upper bound returns the first iterator greater than 'addr'.
+        auto it = allocations.upper_bound(addr);
+        // If 'it' is not the first in the map, step back one to see if that
+        // allocation covers 'addr'.
+        if ( it != allocations.begin() ) {
+            --it;
+            uint64_t          allocStart = it->first;
+            const Allocation& info       = it->second;
+            if ( addr >= allocStart && addr < (allocStart + info.size) ) {
+                return {allocStart, info};
+            }
+        }
+        throw std::runtime_error("SimpleMemoryManager: address not in any allocation");
+    }
 
-  // Iterator to the last allocated block in memory
-  // Used for "next-block" allocation strategy
-  std::list<std::pair<uint64_t, uint64_t>>::iterator next;
+    // A single contiguous buffer
+    std::vector<char> Mem;
 
-  // Map from "address" (offset) -> Allocation metadata
-  std::map<uint64_t, Allocation> allocations;
+    // All available memory blocks, available as pairs [beginAddr, size]
+    std::list<std::pair<uint64_t, uint64_t>> freeBlocks;
 
+    // Iterator to the last allocated block in memory
+    // Used for "next-block" allocation strategy
+    std::list<std::pair<uint64_t, uint64_t>>::iterator next;
+
+    // Map from "address" (offset) -> Allocation metadata
+    std::map<uint64_t, Allocation> allocations;
 };
-}
+}  // namespace mlir
 
 // TODO: Eventaully add something for, say, a DRAMSimMemoryManager or other popular memory systems.
 
-#endif // MLIR_INTERPRETER_MEMORYMANAGER_H
+#endif  // MLIR_INTERPRETER_MEMORYMANAGER_H

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ===- lib/Interpreter/CMakeLists.txt
 #
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/Interpreter/Dialects/Arith/ArithInterpreter.cpp
+++ b/lib/Interpreter/Dialects/Arith/ArithInterpreter.cpp
@@ -1,7 +1,7 @@
 //===- ArithInterpreter.cpp - Arith dialect interpreter -------------*- C++
 //-*-===//
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-#include "mlir/Interpreter/Dialects/ArithInterpreter.h"
 #include "MLIFormat.h"
 #include "MLIUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Interpreter/Dialects/ArithInterpreter.h"
 #include "mlir/Interpreter/Interpreter.h"
 #include "mlir/Interpreter/InterpreterOpInterface.h"
 
@@ -30,1278 +30,1055 @@ namespace {
 
 #if NEW_LLVM
 static llvm::RoundingMode convertRoundingMode(arith::RoundingMode mode) {
-  switch (mode) {
-  case arith::RoundingMode::upward:
-    return llvm::RoundingMode::TowardPositive;
-  case arith::RoundingMode::downward:
-    return llvm::RoundingMode::TowardNegative;
-  case arith::RoundingMode::toward_zero:
-    return llvm::RoundingMode::TowardZero;
-  case arith::RoundingMode::to_nearest_even:
-    return llvm::RoundingMode::NearestTiesToEven;
-  case arith::RoundingMode::to_nearest_away:
-    return llvm::RoundingMode::NearestTiesToAway;
-  default:
-    return llvm::RoundingMode::NearestTiesToEven;
-  }
+    switch ( mode ) {
+        case arith::RoundingMode::upward: return llvm::RoundingMode::TowardPositive;
+        case arith::RoundingMode::downward: return llvm::RoundingMode::TowardNegative;
+        case arith::RoundingMode::toward_zero: return llvm::RoundingMode::TowardZero;
+        case arith::RoundingMode::to_nearest_even: return llvm::RoundingMode::NearestTiesToEven;
+        case arith::RoundingMode::to_nearest_away: return llvm::RoundingMode::NearestTiesToAway;
+        default: return llvm::RoundingMode::NearestTiesToEven;
+    }
 }
 #endif
 
 // Addition Operations
-struct ArithAddFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithAddFOpInterpreter,
-                                                   arith::AddFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = lhs + rhs;
-    mli::fmt::printResult(llvm::outs(), result);
+struct ArithAddFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithAddFOpInterpreter, arith::AddFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = lhs + rhs;
+        mli::fmt::printResult(llvm::outs(), result);
 
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithAddIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithAddIOpInterpreter,
-                                                   arith::AddIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs + rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
+struct ArithAddIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithAddIOpInterpreter, arith::AddIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs + rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
 
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
 struct ArithAddUIExtendedOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithAddUIExtendedOpInterpreter,
-                                                   arith::AddUIExtendedOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    bool overflow = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.uadd_ov(rhs, overflow);
-    mli::fmt::printResult(llvm::outs(), std::make_pair(result, overflow), isSigned);
-    // Create an EvalValue from the result
-    EvalValue evalResults[2];
-    evalResults[0] = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    evalResults[1] = interpreter.createEvalValue(op->getResult(1).getType(), &overflow, sizeof(overflow));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResults);
-  }
+    : public InterpreterOpInterface::ExternalModel<ArithAddUIExtendedOpInterpreter, arith::AddUIExtendedOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        bool overflow = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.uadd_ov(rhs, overflow);
+        mli::fmt::printResult(llvm::outs(), std::make_pair(result, overflow), isSigned);
+        // Create an EvalValue from the result
+        EvalValue evalResults[2];
+        evalResults[0] = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        evalResults[1] = interpreter.createEvalValue(op->getResult(1).getType(), &overflow, sizeof(overflow));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResults);
+    }
 };
 
-struct ArithAndIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithAndIOpInterpreter,
-                                                   arith::AndIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs & rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithAndIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithAndIOpInterpreter, arith::AndIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs & rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithBitcastOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithBitcastOpInterpreter,
-                                                   arith::BitcastOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    auto src_type = operands[0].getType();
-    auto result_type = op->getOpResult(0).getType();
-    EvalValue evalResult;
+struct ArithBitcastOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithBitcastOpInterpreter, arith::BitcastOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        auto      src_type    = operands[0].getType();
+        auto      result_type = op->getOpResult(0).getType();
+        EvalValue evalResult;
 
-    if (src_type.getIntOrFloatBitWidth() != result_type.getIntOrFloatBitWidth()) {
-        return interpreter.createErrorResult("Types must be of the same width");
+        if ( src_type.getIntOrFloatBitWidth() != result_type.getIntOrFloatBitWidth() ) {
+            return interpreter.createErrorResult("Types must be of the same width");
+        }
+        if ( src_type == result_type ) {  // no-op
+            evalResult = operands[0];
+        }
+        else if ( llvm::isa<mlir::FloatType>(src_type) ) {  // src float, ret int
+            const APFloat lhs = getFloatData(operands[0]);
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+            const APInt result = lhs.bitcastToAPInt();
+            mli::fmt::printResult(llvm::outs(), result);
+            evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+        }
+        else if ( llvm::isa<mlir::IntegerType>(src_type) ) {  // src int, ret float
+            const APInt lhs = getIntegerData(operands[0]);
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+            Semantics     s      = getFloatSemantics(result_type);
+            const APFloat result = APFloat(llvm::APFloat::EnumToSemantics(s), lhs);
+            mli::fmt::printResult(llvm::outs(), result);
+            evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+        }
+        else {
+            return interpreter.createErrorResult("Input is not numeric");
+        }
+        return interpreter.createBindValueResult(evalResult);
     }
-    if (src_type == result_type) { // no-op
-        evalResult = operands[0];
-    }
-    else if (llvm::isa<mlir::FloatType>(src_type)) { // src float, ret int
-        const APFloat lhs = getFloatData(operands[0]);
-        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-        const APInt result = lhs.bitcastToAPInt();
-        mli::fmt::printResult(llvm::outs(), result);
-        evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
-    }
-    else if (llvm::isa<mlir::IntegerType>(src_type)) { // src int, ret float
-        const APInt lhs = getIntegerData(operands[0]);
-        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-        Semantics s = getFloatSemantics(result_type);
-        const APFloat result = APFloat(llvm::APFloat::EnumToSemantics(s), lhs);
-        mli::fmt::printResult(llvm::outs(), result);
-        evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
-    }
-    else {
-        return interpreter.createErrorResult("Input is not numeric");
-    }
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
-struct ArithCeilDivSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithCeilDivSIOpInterpreter,
-                                                   arith::CeilDivSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+struct ArithCeilDivSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithCeilDivSIOpInterpreter, arith::CeilDivSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
 
-    // const APInt doesn't have a ceiling division function so rely on remainder
-    APInt result, remainder;
-    APInt::sdivrem(lhs, rhs, result, remainder);
+        // const APInt doesn't have a ceiling division function so rely on remainder
+        APInt result, remainder;
+        APInt::sdivrem(lhs, rhs, result, remainder);
 
-    // If the quotient is negative, standard division behaves the same as ceiling
-    // Otherwise, if the quotient isn't an integer, we need to add one for the ceiling
-    if (remainder != 0 && result.isStrictlyPositive()) {
-        result = ++result;
+        // If the quotient is negative, standard division behaves the same as ceiling
+        // Otherwise, if the quotient isn't an integer, we need to add one for the ceiling
+        if ( remainder != 0 && result.isStrictlyPositive() ) {
+            result = ++result;
+        }
+
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
     }
-
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
-struct ArithCeilDivUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithCeilDivUIOpInterpreter,
-                                                   arith::CeilDivUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+struct ArithCeilDivUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithCeilDivUIOpInterpreter, arith::CeilDivUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
 
-    // APInt doesn't have a ceiling division function so rely on remainder
-    APInt result, remainder;
-    APInt::udivrem(lhs, rhs, result, remainder);
+        // APInt doesn't have a ceiling division function so rely on remainder
+        APInt result, remainder;
+        APInt::udivrem(lhs, rhs, result, remainder);
 
-    if (remainder != 0) {
-        result = ++result;
+        if ( remainder != 0 ) {
+            result = ++result;
+        }
+
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
     }
-
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
 // Comparison Operations
-struct ArithCmpFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithCmpFOpInterpreter,
-                                                   arith::CmpFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    auto predicate =
-        op->getAttrOfType<arith::CmpFPredicateAttr>("predicate").getValue();
+struct ArithCmpFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithCmpFOpInterpreter, arith::CmpFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        auto predicate    = op->getAttrOfType<arith::CmpFPredicateAttr>("predicate").getValue();
 
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
 
-    bool result;
-    bool one_NaN = lhs.isNaN() || rhs.isNaN();
+        bool result;
+        bool one_NaN = lhs.isNaN() || rhs.isNaN();
 
-    // FCmp supports both ordered and unordered comparisons
-    // Any ordered comparison returns false if at least one argument is NaN
-    // Any unordered comparison returns true if at least one argument is NaN
-    switch (predicate) {
-        case arith::CmpFPredicate::AlwaysFalse:
-            result = false;
-            break;
-        case arith::CmpFPredicate::OEQ:
-            result = !one_NaN && lhs == rhs;
-            break;
-        case arith::CmpFPredicate::OGT:
-            result = !one_NaN && lhs > rhs;
-            break;
-        case arith::CmpFPredicate::OGE:
-            result = !one_NaN && lhs >= rhs;
-            break;
-        case arith::CmpFPredicate::OLT:
-            result = !one_NaN && lhs < rhs;
-            break;
-        case arith::CmpFPredicate::ONE:
-            result = !one_NaN && lhs != rhs;
-            break;
-        case arith::CmpFPredicate::ORD:
-            result = !one_NaN;
-            break;
-        case arith::CmpFPredicate::UEQ:
-            result = one_NaN || lhs == rhs;
-            break;
-        case arith::CmpFPredicate::UGT:
-            result = one_NaN || lhs > rhs;
-            break;
-        case arith::CmpFPredicate::UGE:
-            result = one_NaN || lhs >= rhs;
-            break;
-        case arith::CmpFPredicate::ULT:
-            result = one_NaN || lhs < rhs;
-            break;
-        case arith::CmpFPredicate::ULE:
-            result = one_NaN || lhs <= rhs;
-            break;
-        case arith::CmpFPredicate::UNE:
-            result = one_NaN || lhs != rhs;
-            break;
-        case arith::CmpFPredicate::UNO:
-            result = one_NaN;
-            break;
-        default:
-            result = true;
+        // FCmp supports both ordered and unordered comparisons
+        // Any ordered comparison returns false if at least one argument is NaN
+        // Any unordered comparison returns true if at least one argument is NaN
+        switch ( predicate ) {
+            case arith::CmpFPredicate::AlwaysFalse: result = false; break;
+            case arith::CmpFPredicate::OEQ: result = !one_NaN && lhs == rhs; break;
+            case arith::CmpFPredicate::OGT: result = !one_NaN && lhs > rhs; break;
+            case arith::CmpFPredicate::OGE: result = !one_NaN && lhs >= rhs; break;
+            case arith::CmpFPredicate::OLT: result = !one_NaN && lhs < rhs; break;
+            case arith::CmpFPredicate::ONE: result = !one_NaN && lhs != rhs; break;
+            case arith::CmpFPredicate::ORD: result = !one_NaN; break;
+            case arith::CmpFPredicate::UEQ: result = one_NaN || lhs == rhs; break;
+            case arith::CmpFPredicate::UGT: result = one_NaN || lhs > rhs; break;
+            case arith::CmpFPredicate::UGE: result = one_NaN || lhs >= rhs; break;
+            case arith::CmpFPredicate::ULT: result = one_NaN || lhs < rhs; break;
+            case arith::CmpFPredicate::ULE: result = one_NaN || lhs <= rhs; break;
+            case arith::CmpFPredicate::UNE: result = one_NaN || lhs != rhs; break;
+            case arith::CmpFPredicate::UNO: result = one_NaN; break;
+            default: result = true;
+        }
+
+        mli::fmt::printResult(llvm::outs(), result);
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
     }
-
-    mli::fmt::printResult(llvm::outs(), result);
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
-struct ArithCmpIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithCmpIOpInterpreter,
-                                                   arith::CmpIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    auto predicate =
-        op->getAttrOfType<arith::CmpIPredicateAttr>("predicate").getValue();
-    bool isSigned = predicate == arith::CmpIPredicate::slt ||
-                    predicate == arith::CmpIPredicate::sle ||
-                    predicate == arith::CmpIPredicate::sgt ||
-                    predicate == arith::CmpIPredicate::sge;
+struct ArithCmpIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithCmpIOpInterpreter, arith::CmpIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        auto predicate = op->getAttrOfType<arith::CmpIPredicateAttr>("predicate").getValue();
+        bool isSigned  = predicate == arith::CmpIPredicate::slt || predicate == arith::CmpIPredicate::sle ||
+                        predicate == arith::CmpIPredicate::sgt || predicate == arith::CmpIPredicate::sge;
 
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
 
-    bool result;
-    switch (predicate) {
-    case arith::CmpIPredicate::eq:
-      result = lhs.eq(rhs);
-      break;
-    case arith::CmpIPredicate::ne:
-      result = lhs.ne(rhs);
-      break;
-    case arith::CmpIPredicate::slt:
-      result = lhs.slt(rhs);
-      break;
-    case arith::CmpIPredicate::sle:
-      result = lhs.sle(rhs);
-      break;
-    case arith::CmpIPredicate::sgt:
-      result = lhs.sgt(rhs);
-      break;
-    case arith::CmpIPredicate::sge:
-      result = lhs.sge(rhs);
-      break;
-    case arith::CmpIPredicate::ult:
-      result = lhs.ult(rhs);
-      break;
-    case arith::CmpIPredicate::ule:
-      result = lhs.ule(rhs);
-      break;
-    case arith::CmpIPredicate::ugt:
-      result = lhs.ugt(rhs);
-      break;
-    case arith::CmpIPredicate::uge:
-      result = lhs.uge(rhs);
-      break;
-    default:
-      result = false;
+        bool result;
+        switch ( predicate ) {
+            case arith::CmpIPredicate::eq: result = lhs.eq(rhs); break;
+            case arith::CmpIPredicate::ne: result = lhs.ne(rhs); break;
+            case arith::CmpIPredicate::slt: result = lhs.slt(rhs); break;
+            case arith::CmpIPredicate::sle: result = lhs.sle(rhs); break;
+            case arith::CmpIPredicate::sgt: result = lhs.sgt(rhs); break;
+            case arith::CmpIPredicate::sge: result = lhs.sge(rhs); break;
+            case arith::CmpIPredicate::ult: result = lhs.ult(rhs); break;
+            case arith::CmpIPredicate::ule: result = lhs.ule(rhs); break;
+            case arith::CmpIPredicate::ugt: result = lhs.ugt(rhs); break;
+            case arith::CmpIPredicate::uge: result = lhs.uge(rhs); break;
+            default: result = false;
+        }
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        mli::fmt::printResult(llvm::outs(), result);
+        return interpreter.createBindValueResult(evalResult);
     }
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    mli::fmt::printResult(llvm::outs(), result);
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
 // Constant Operation
-struct ArithConstantOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithConstantOpInterpreter,
-                                                   arith::ConstantOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    auto attr = op->getAttr("value");
-    auto result_type = op->getResult(0).getType();
-    EvalValue evalResult;
+struct ArithConstantOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithConstantOpInterpreter, arith::ConstantOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        auto      attr        = op->getAttr("value");
+        auto      result_type = op->getResult(0).getType();
+        EvalValue evalResult;
 
-    // Is integer or index type
-    if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
-        const APInt val = intAttr.getValue();
-        if (mlir::isa<mlir::IndexType>(result_type)) {
-            intptr_t result = static_cast<intptr_t>(val.sextOrTrunc(sizeof(intptr_t) * 8).getSExtValue());
-            evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
-            llvm::outs() << mli::fmt::dim("Initializing constant ") << result << "\n";
+        // Is integer or index type
+        if ( auto intAttr = dyn_cast<IntegerAttr>(attr) ) {
+            const APInt val = intAttr.getValue();
+            if ( mlir::isa<mlir::IndexType>(result_type) ) {
+                intptr_t result = static_cast<intptr_t>(val.sextOrTrunc(sizeof(intptr_t) * 8).getSExtValue());
+                evalResult      = interpreter.createEvalValue(result_type, &result, sizeof(result));
+                llvm::outs() << mli::fmt::dim("Initializing constant ") << result << "\n";
+            }
+            else {
+                evalResult = interpreter.createEvalValue(result_type, &val, sizeof(val));
+                llvm::outs() << mli::fmt::dim("Initializing constant ") << val << "\n";
+            }
+        }
+        else if ( auto floatAttr = dyn_cast<FloatAttr>(attr) ) {
+            const APFloat result = floatAttr.getValue();
+            evalResult           = interpreter.createEvalValue(result_type, &result, sizeof(result));
+            llvm::outs() << mli::fmt::dim("Initializing constant ") << mli::fmt::to_string(result) << "\n";
         }
         else {
-            evalResult = interpreter.createEvalValue(result_type, &val, sizeof(val));
-            llvm::outs() << mli::fmt::dim("Initializing constant ") << val << "\n";
+            return interpreter.createErrorResult("Unsupported constant type");
         }
-    } else if (auto floatAttr = dyn_cast<FloatAttr>(attr)) {
-        const APFloat result = floatAttr.getValue();
-        evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
-        llvm::outs() << mli::fmt::dim("Initializing constant ") << mli::fmt::to_string(result) << "\n";
-    } else {
-        return interpreter.createErrorResult("Unsupported constant type");
+        return interpreter.createBindValueResult(evalResult);
     }
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
 // Floating point division
-struct ArithDivFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithDivFOpInterpreter,
-                                                   arith::DivFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+struct ArithDivFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithDivFOpInterpreter, arith::DivFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
 
-    const APFloat result = lhs / rhs;
-    mli::fmt::printResult(llvm::outs(), result);
+        const APFloat result = lhs / rhs;
+        mli::fmt::printResult(llvm::outs(), result);
 
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithDivSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithDivSIOpInterpreter,
-                                                   arith::DivSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.sdiv(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithDivSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithDivSIOpInterpreter, arith::DivSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.sdiv(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithDivUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithDivUIOpInterpreter,
-                                                   arith::DivUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.udiv(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithDivUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithDivUIOpInterpreter, arith::DivUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.udiv(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithExtFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithExtFOpInterpreter,
-                                                   arith::ExtFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat operand = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand);
+struct ArithExtFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithExtFOpInterpreter, arith::ExtFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat operand = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand);
 
-    bool losesInfo;
-    auto resultType = op->getResult(0).getType();
-    APFloat result = operand;
-    Semantics resultSemantics = getFloatSemantics(resultType);
-    result.convert(llvm::APFloatBase::EnumToSemantics(resultSemantics),
-                    llvm::RoundingMode::TowardZero, &losesInfo);
+        bool      losesInfo;
+        auto      resultType      = op->getResult(0).getType();
+        APFloat   result          = operand;
+        Semantics resultSemantics = getFloatSemantics(resultType);
+        result.convert(llvm::APFloatBase::EnumToSemantics(resultSemantics), llvm::RoundingMode::TowardZero, &losesInfo);
 
-    mli::fmt::printResult(llvm::outs(), result);
-    auto evalResult =
-        interpreter.createEvalValue(resultType, &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        mli::fmt::printResult(llvm::outs(), result);
+        auto evalResult = interpreter.createEvalValue(resultType, &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithExtSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithExtSIOpInterpreter,
-                                                   arith::ExtSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    unsigned new_width = op->getResult(0).getType().getIntOrFloatBitWidth();
-    const APInt result = lhs.sext(new_width);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithExtSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithExtSIOpInterpreter, arith::ExtSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        unsigned    new_width = op->getResult(0).getType().getIntOrFloatBitWidth();
+        const APInt result    = lhs.sext(new_width);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithExtUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithExtUIOpInterpreter,
-                                                   arith::ExtUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    unsigned new_width = op->getResult(0).getType().getIntOrFloatBitWidth();
+struct ArithExtUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithExtUIOpInterpreter, arith::ExtUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        unsigned new_width = op->getResult(0).getType().getIntOrFloatBitWidth();
 
-    const APInt result = lhs.zext(new_width);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        const APInt result = lhs.zext(new_width);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
 struct ArithFloorDivSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithFloorDivSIOpInterpreter,
-                                                   arith::FloorDivSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    
-    #if NEW_LLVM
-        bool overflow = false;
-        const APInt result = lhs.sfloordiv_ov(rhs, overflow);
-    #else
+    : public InterpreterOpInterface::ExternalModel<ArithFloorDivSIOpInterpreter, arith::FloorDivSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+
+#if NEW_LLVM
+        bool        overflow = false;
+        const APInt result   = lhs.sfloordiv_ov(rhs, overflow);
+#else
         // We need to subtract one for floor if the result is negative and not an integer
         // The sign of the quotient must be computed beforehand, since it can be lost in integer division
         // e.g. -1 / 2 = 0, which isn't negative like we mathematically expect it to be
-        bool quotient_is_negative = lhs.isNegative() != rhs.isNegative();
+        bool  quotient_is_negative = lhs.isNegative() != rhs.isNegative();
         APInt result, remainder;
         APInt::sdivrem(lhs, rhs, result, remainder);
-        if (remainder != 0 && quotient_is_negative) {
+        if ( remainder != 0 && quotient_is_negative ) {
             result = result - 1;
         }
-    #endif
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithFPToSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithFPToSIOpInterpreter,
-                                                   arith::FPToSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat operand = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand);
-
-    unsigned resultWidth = op->getResult(0).getType().getIntOrFloatBitWidth();
-    bool isUnsigned = false;
-    APSInt result(resultWidth, isUnsigned);
-    bool isExact;
-    operand.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
-
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithFPToUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithFPToUIOpInterpreter,
-                                                   arith::FPToUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat operand = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand);
-
-    unsigned resultWidth = op->getResult(0).getType().getIntOrFloatBitWidth();
-    bool isUnsigned = true;
-    APSInt result(resultWidth, isUnsigned);
-    bool isExact;
-    operand.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
-
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithIndexCastOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithIndexCastOpInterpreter,
-                                                   arith::IndexCastOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    auto src_type = operands[0].getType();
-    auto dest_type = op->getResult(0).getType();
-
-    EvalValue evalResult;
-    if (mlir::isa<mlir::IntegerType>(src_type) && mlir::isa<mlir::IndexType>(dest_type)) {
-        const APInt lhs = getIntegerData(operands[0], isSigned);
-        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-        intptr_t result = static_cast<intptr_t>(
-            lhs.sextOrTrunc(sizeof(intptr_t) * 8).getSExtValue());
+#endif
         mli::fmt::printResult(llvm::outs(), result, isSigned);
-        evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
     }
-    else if (mlir::isa<mlir::IndexType>(src_type) && mlir::isa<mlir::IntegerType>(dest_type)) {
-        intptr_t lhs = operands[0].getData<intptr_t>().front();
-        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-        const APInt result = APInt(dest_type.getIntOrFloatBitWidth(), lhs, isSigned);
-        mli::fmt::printResult(llvm::outs(), result, isSigned);
-        evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));        
-    }
+};
 
-    // Create an EvalValue from the result
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithFPToSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithFPToSIOpInterpreter, arith::FPToSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat operand = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand);
+
+        unsigned resultWidth = op->getResult(0).getType().getIntOrFloatBitWidth();
+        bool     isUnsigned  = false;
+        APSInt   result(resultWidth, isUnsigned);
+        bool     isExact;
+        operand.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
+
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithFPToUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithFPToUIOpInterpreter, arith::FPToUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat operand = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand);
+
+        unsigned resultWidth = op->getResult(0).getType().getIntOrFloatBitWidth();
+        bool     isUnsigned  = true;
+        APSInt   result(resultWidth, isUnsigned);
+        bool     isExact;
+        operand.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
+
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithIndexCastOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithIndexCastOpInterpreter, arith::IndexCastOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        auto src_type  = operands[0].getType();
+        auto dest_type = op->getResult(0).getType();
+
+        EvalValue evalResult;
+        if ( mlir::isa<mlir::IntegerType>(src_type) && mlir::isa<mlir::IndexType>(dest_type) ) {
+            const APInt lhs = getIntegerData(operands[0], isSigned);
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+            intptr_t result = static_cast<intptr_t>(lhs.sextOrTrunc(sizeof(intptr_t) * 8).getSExtValue());
+            mli::fmt::printResult(llvm::outs(), result, isSigned);
+            evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));
+        }
+        else if ( mlir::isa<mlir::IndexType>(src_type) && mlir::isa<mlir::IntegerType>(dest_type) ) {
+            intptr_t lhs = operands[0].getData<intptr_t>().front();
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+            const APInt result = APInt(dest_type.getIntOrFloatBitWidth(), lhs, isSigned);
+            mli::fmt::printResult(llvm::outs(), result, isSigned);
+            evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));
+        }
+
+        // Create an EvalValue from the result
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
 struct ArithIndexCastUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithIndexCastUIOpInterpreter,
-                                                   arith::IndexCastUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    auto src_type = operands[0].getType();
-    auto dest_type = op->getResult(0).getType();
+    : public InterpreterOpInterface::ExternalModel<ArithIndexCastUIOpInterpreter, arith::IndexCastUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        auto src_type  = operands[0].getType();
+        auto dest_type = op->getResult(0).getType();
 
-    EvalValue evalResult;
-    if (mlir::isa<mlir::IntegerType>(src_type) && mlir::isa<mlir::IndexType>(dest_type)) {
-        const APInt lhs = getIntegerData(operands[0], isSigned);
-        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-        intptr_t result = static_cast<intptr_t>(
-            lhs.sextOrTrunc(sizeof(intptr_t) * 8).getSExtValue());
-        mli::fmt::printResult(llvm::outs(), result, isSigned);
-        evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));
+        EvalValue evalResult;
+        if ( mlir::isa<mlir::IntegerType>(src_type) && mlir::isa<mlir::IndexType>(dest_type) ) {
+            const APInt lhs = getIntegerData(operands[0], isSigned);
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+            intptr_t result = static_cast<intptr_t>(lhs.sextOrTrunc(sizeof(intptr_t) * 8).getSExtValue());
+            mli::fmt::printResult(llvm::outs(), result, isSigned);
+            evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));
+        }
+        else if ( mlir::isa<mlir::IndexType>(src_type) && mlir::isa<mlir::IntegerType>(dest_type) ) {
+            intptr_t lhs = operands[0].getData<intptr_t>().front();
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+            const APInt result = APInt(dest_type.getIntOrFloatBitWidth(), lhs, isSigned);
+            mli::fmt::printResult(llvm::outs(), result, isSigned);
+            evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));
+        }
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
     }
-    else if (mlir::isa<mlir::IndexType>(src_type) && mlir::isa<mlir::IntegerType>(dest_type)) {
-        intptr_t lhs = operands[0].getData<intptr_t>().front();
-        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-        const APInt result = APInt(dest_type.getIntOrFloatBitWidth(), lhs, isSigned);
-        mli::fmt::printResult(llvm::outs(), result, isSigned);
-        evalResult = interpreter.createEvalValue(dest_type, &result, sizeof(result));        
-    }
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
 // Maximum/Minimum Operations
-struct ArithMaximumFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMaximumFOpInterpreter,
-                                                   arith::MaximumFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+struct ArithMaximumFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMaximumFOpInterpreter, arith::MaximumFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
 
-    const APFloat result = llvm::maximum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
+        const APFloat result = llvm::maximum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
 
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMaxNumFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMaxNumFOpInterpreter,
-                                                   arith::MaxNumFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    const APFloat result = maxnum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithMaxNumFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMaxNumFOpInterpreter, arith::MaxNumFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs    = getFloatData(operands[1]);
+        const APFloat result = maxnum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMaxSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMaxSIOpInterpreter,
-                                                   arith::MaxSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = APIntOps::smax(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithMaxSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMaxSIOpInterpreter, arith::MaxSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = APIntOps::smax(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMaxUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMaxUIOpInterpreter,
-                                                   arith::MaxUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = APIntOps::umax(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithMaxUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMaxUIOpInterpreter, arith::MaxUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = APIntOps::umax(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMinimumFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMinimumFOpInterpreter,
-                                                   arith::MinimumFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+struct ArithMinimumFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMinimumFOpInterpreter, arith::MinimumFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
 
-    const APFloat result = llvm::minimum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
+        const APFloat result = llvm::minimum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
 
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMinNumFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMinNumFOpInterpreter,
-                                                   arith::MinNumFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    const APFloat result = llvm::minnum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithMinNumFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMinNumFOpInterpreter, arith::MinNumFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs    = getFloatData(operands[1]);
+        const APFloat result = llvm::minnum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMinSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMinSIOpInterpreter,
-                                                   arith::MinSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = APIntOps::smin(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithMinSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMinSIOpInterpreter, arith::MinSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = APIntOps::smin(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMinUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMinUIOpInterpreter,
-                                                   arith::MinUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = APIntOps::umin(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithMinUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMinUIOpInterpreter, arith::MinUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = APIntOps::umin(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMulFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMulFOpInterpreter,
-                                                   arith::MulFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+struct ArithMulFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMulFOpInterpreter, arith::MulFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
 
-    const APFloat result = lhs * rhs;
-    mli::fmt::printResult(llvm::outs(), result);
+        const APFloat result = lhs * rhs;
+        mli::fmt::printResult(llvm::outs(), result);
 
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithMulIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMulIOpInterpreter,
-                                                   arith::MulIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs * rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithMulIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithMulIOpInterpreter, arith::MulIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs * rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
 struct ArithMulSIExtendedOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMulSIExtendedOpInterpreter,
-                                                   arith::MulSIExtendedOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+    : public InterpreterOpInterface::ExternalModel<ArithMulSIExtendedOpInterpreter, arith::MulSIExtendedOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
 
-    const unsigned op_width = operands[0].getType().getIntOrFloatBitWidth();
-    APInt prod = lhs.sext(2 * op_width);
-    prod *= rhs.sext(2 * op_width);
-    const APInt low = prod.extractBits(op_width, 0);
-    const APInt high = prod.extractBits(op_width, op_width);
-    mli::fmt::printResult(llvm::outs(), std::make_pair(low, high), isSigned);
+        const unsigned op_width = operands[0].getType().getIntOrFloatBitWidth();
+        APInt          prod     = lhs.sext(2 * op_width);
+        prod *= rhs.sext(2 * op_width);
+        const APInt low  = prod.extractBits(op_width, 0);
+        const APInt high = prod.extractBits(op_width, op_width);
+        mli::fmt::printResult(llvm::outs(), std::make_pair(low, high), isSigned);
 
-    // Create an EvalValue from the result
-    EvalValue evalResults[2];
-    evalResults[0] = interpreter.createEvalValue(op->getResult(0).getType(), &low, sizeof(low));
-    evalResults[1] = interpreter.createEvalValue(op->getResult(1).getType(), &high, sizeof(high));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResults);
-  }
+        // Create an EvalValue from the result
+        EvalValue evalResults[2];
+        evalResults[0] = interpreter.createEvalValue(op->getResult(0).getType(), &low, sizeof(low));
+        evalResults[1] = interpreter.createEvalValue(op->getResult(1).getType(), &high, sizeof(high));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResults);
+    }
 };
 
 struct ArithMulUIExtendedOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithMulUIExtendedOpInterpreter,
-                                                   arith::MulUIExtendedOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+    : public InterpreterOpInterface::ExternalModel<ArithMulUIExtendedOpInterpreter, arith::MulUIExtendedOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
 
-    const unsigned op_width = operands[0].getType().getIntOrFloatBitWidth();
-    APInt prod = lhs.sext(2 * op_width);
-    prod *= rhs.sext(2 * op_width);
-    const APInt low = prod.extractBits(op_width, 0);
-    const APInt high = prod.extractBits(op_width, op_width);
-    mli::fmt::printResult(llvm::outs(), std::make_pair(low, high), isSigned);
+        const unsigned op_width = operands[0].getType().getIntOrFloatBitWidth();
+        APInt          prod     = lhs.sext(2 * op_width);
+        prod *= rhs.sext(2 * op_width);
+        const APInt low  = prod.extractBits(op_width, 0);
+        const APInt high = prod.extractBits(op_width, op_width);
+        mli::fmt::printResult(llvm::outs(), std::make_pair(low, high), isSigned);
 
-    // Create an EvalValue from the result
-    EvalValue evalResults[2];
-    evalResults[0] = interpreter.createEvalValue(op->getResult(0).getType(), &low, sizeof(low));
-    evalResults[1] = interpreter.createEvalValue(op->getResult(1).getType(), &high, sizeof(high));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResults);
-  }
+        // Create an EvalValue from the result
+        EvalValue evalResults[2];
+        evalResults[0] = interpreter.createEvalValue(op->getResult(0).getType(), &low, sizeof(low));
+        evalResults[1] = interpreter.createEvalValue(op->getResult(1).getType(), &high, sizeof(high));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResults);
+    }
 };
 
-struct ArithNegFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithNegFOpInterpreter,
-                                                   arith::NegFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat operand = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand);
+struct ArithNegFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithNegFOpInterpreter, arith::NegFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat operand = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand);
 
-    const APFloat result = -operand;
-    mli::fmt::printResult(llvm::outs(), result);
+        const APFloat result = -operand;
+        mli::fmt::printResult(llvm::outs(), result);
 
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithOrIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithOrIOpInterpreter,
-                                                   arith::OrIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs | rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithOrIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithOrIOpInterpreter, arith::OrIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs | rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithRemFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithRemFOpInterpreter,
-                                                   arith::RemFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+struct ArithRemFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithRemFOpInterpreter, arith::RemFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
 
-    APFloat result = lhs;
-    result.mod(rhs);
+        APFloat result = lhs;
+        result.mod(rhs);
 
-    mli::fmt::printResult(llvm::outs(), result);
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+        mli::fmt::printResult(llvm::outs(), result);
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithRemSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithRemSIOpInterpreter,
-                                                   arith::RemSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.srem(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithRemSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithRemSIOpInterpreter, arith::RemSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.srem(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithRemUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithRemUIOpInterpreter,
-                                                   arith::RemUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.urem(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithRemUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithRemUIOpInterpreter, arith::RemUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.urem(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
 // Select Operation
-struct ArithSelectOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithSelectOpInterpreter,
-                                                   arith::SelectOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    bool condition = operands[0].getData<bool>().front();
-    EvalValue result = condition ? operands[1] : operands[2];
-    llvm::outs() << mli::fmt::dim("result: ") << result << "\n";
-    return interpreter.createBindValueResult(result);
-  }
-};
-
-struct ArithShLIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithShLIOpInterpreter,
-                                                   arith::ShLIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], false);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, false);
-    const APInt result = lhs << rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithShRSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithShRSIOpInterpreter,
-                                                   arith::ShRSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], false);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, false);
-    const APInt result = lhs.ashr(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithShRUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithShRUIOpInterpreter,
-                                                   arith::ShRUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.lshr(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithSIToFPOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithSIToFPOpInterpreter,
-                                                   arith::SIToFPOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    bool isSigned = true;
-    const APInt operand = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand, isSigned);
-
-    auto resultType = op->getResult(0).getType();
-    Semantics resultSemantics = getFloatSemantics(resultType);
-    APFloat result(llvm::APFloatBase::EnumToSemantics(resultSemantics));
-    result.convertFromAPInt(operand, isSigned, llvm::RoundingMode::TowardZero);
-
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult =
-        interpreter.createEvalValue(resultType, &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithSubFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithSubFOpInterpreter,
-                                                   arith::SubFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-
-    const APFloat result = lhs - rhs;
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(),
-                                                  &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithSubIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithSubIOpInterpreter,
-                                                   arith::SubIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs-rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct ArithTruncFOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithTruncFOpInterpreter,
-                                                   arith::TruncFOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat operand = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand);
-
-    // Get rounding mode from optional attribute
-    llvm::RoundingMode roundingMode = llvm::RoundingMode::NearestTiesToEven;
-    #if NEW_LLVM
-    if (auto modeAttr =
-        op->getAttrOfType<arith::RoundingModeAttr>("roundingmode")) {
-        roundingMode = convertRoundingMode(modeAttr.getValue());
-        llvm::outs() << mli::fmt::dim("Using specified rounding mode: ") << roundingMode << "\n";
-    } 
-    #endif
-    llvm::outs() << mli::fmt::dim("Using default rounding mode: NearestTiesToEven") << "\n";
-
-    bool losesInfo;
-    auto resultType = op->getResult(0).getType();
-    Semantics resultSemantics = getFloatSemantics(resultType);
-
-    // Convert using the determined rounding mode
-    APFloat result = operand;
-    result.convert(llvm::APFloatBase::EnumToSemantics(resultSemantics),
-                    roundingMode, &losesInfo);
-
-    if (losesInfo) {
-      llvm::outs() << mli::fmt::warning("Precision loss during truncation")
-                   << "\n";
+struct ArithSelectOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithSelectOpInterpreter, arith::SelectOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        bool      condition = operands[0].getData<bool>().front();
+        EvalValue result    = condition ? operands[1] : operands[2];
+        llvm::outs() << mli::fmt::dim("result: ") << result << "\n";
+        return interpreter.createBindValueResult(result);
     }
-
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult =
-        interpreter.createEvalValue(resultType, &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
-struct ArithTruncIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithTruncIOpInterpreter,
-                                                   arith::TruncIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt operand = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand, isSigned);
-
-    const unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
-    const APInt result = operand.trunc(result_width);
-
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithShLIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithShLIOpInterpreter, arith::ShLIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], false);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, false);
+        const APInt result = lhs << rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithUIToFPOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithUIToFPOpInterpreter,
-                                                   arith::UIToFPOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    bool isSigned = false;
-    const APInt operand = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "operand", operand, isSigned);
-
-    auto resultType = op->getResult(0).getType();
-    Semantics resultSemantics = getFloatSemantics(resultType);
-    APFloat result(llvm::APFloatBase::EnumToSemantics(resultSemantics));
-    result.convertFromAPInt(operand, isSigned, llvm::RoundingMode::TowardZero);
-
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult =
-        interpreter.createEvalValue(resultType, &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithShRSIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithShRSIOpInterpreter, arith::ShRSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], false);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, false);
+        const APInt result = lhs.ashr(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct ArithXOrIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ArithXOrIOpInterpreter,
-                                                   arith::XOrIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs ^ rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct ArithShRUIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithShRUIOpInterpreter, arith::ShRUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.lshr(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-} // end anonymous namespace
+struct ArithSIToFPOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithSIToFPOpInterpreter, arith::SIToFPOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        bool        isSigned = true;
+        const APInt operand  = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand, isSigned);
 
-void ArithInterpreter::attachInterface(MLIRContext &context) {
-  arith::AddFOp::attachInterface<ArithAddFOpInterpreter>(context);
-  arith::AddIOp::attachInterface<ArithAddIOpInterpreter>(context);
-  arith::AddUIExtendedOp::attachInterface<ArithAddUIExtendedOpInterpreter>(context);
-  arith::AndIOp::attachInterface<ArithAndIOpInterpreter>(context);
-  arith::BitcastOp::attachInterface<ArithBitcastOpInterpreter>(context);
-  arith::CeilDivSIOp::attachInterface<ArithCeilDivSIOpInterpreter>(context);
-  arith::CeilDivUIOp::attachInterface<ArithCeilDivUIOpInterpreter>(context);
-  arith::CmpFOp::attachInterface<ArithCmpFOpInterpreter>(context);
-  arith::CmpIOp::attachInterface<ArithCmpIOpInterpreter>(context);
-  arith::DivFOp::attachInterface<ArithDivFOpInterpreter>(context);
-  arith::DivSIOp::attachInterface<ArithDivSIOpInterpreter>(context);
-  arith::DivUIOp::attachInterface<ArithDivUIOpInterpreter>(context);
-  arith::ExtFOp::attachInterface<ArithExtFOpInterpreter>(context);
-  arith::ExtSIOp::attachInterface<ArithExtSIOpInterpreter>(context);
-  arith::ExtUIOp::attachInterface<ArithExtUIOpInterpreter>(context);
-  arith::ConstantOp::attachInterface<ArithConstantOpInterpreter>(context);
-  arith::IndexCastOp::attachInterface<ArithIndexCastOpInterpreter>(context);
-  arith::IndexCastUIOp::attachInterface<ArithIndexCastUIOpInterpreter>(context);
-  arith::FloorDivSIOp::attachInterface<ArithFloorDivSIOpInterpreter>(context);
-  arith::FPToSIOp::attachInterface<ArithFPToSIOpInterpreter>(context);
-  arith::FPToUIOp::attachInterface<ArithFPToUIOpInterpreter>(context);
-  arith::MaximumFOp::attachInterface<ArithMaximumFOpInterpreter>(context);
-  arith::MaxNumFOp::attachInterface<ArithMaxNumFOpInterpreter>(context);
-  arith::MaxSIOp::attachInterface<ArithMaxSIOpInterpreter>(context);
-  arith::MaxUIOp::attachInterface<ArithMaxUIOpInterpreter>(context);
-  arith::MinimumFOp::attachInterface<ArithMinimumFOpInterpreter>(context);
-  arith::MinNumFOp::attachInterface<ArithMinNumFOpInterpreter>(context);
-  arith::MinSIOp::attachInterface<ArithMinSIOpInterpreter>(context);
-  arith::MinUIOp::attachInterface<ArithMinUIOpInterpreter>(context);
-  arith::MulFOp::attachInterface<ArithMulFOpInterpreter>(context);
-  arith::MulIOp::attachInterface<ArithMulIOpInterpreter>(context);
-  arith::MulSIExtendedOp::attachInterface<ArithMulSIExtendedOpInterpreter>(context);
-  arith::MulUIExtendedOp::attachInterface<ArithMulUIExtendedOpInterpreter>(context);
-  arith::OrIOp::attachInterface<ArithOrIOpInterpreter>(context);
-  arith::NegFOp::attachInterface<ArithNegFOpInterpreter>(context);
-  arith::RemFOp::attachInterface<ArithRemFOpInterpreter>(context);
-  arith::RemSIOp::attachInterface<ArithRemSIOpInterpreter>(context);
-  arith::RemUIOp::attachInterface<ArithRemUIOpInterpreter>(context);
-  arith::SelectOp::attachInterface<ArithSelectOpInterpreter>(context);
-  arith::ShLIOp::attachInterface<ArithShLIOpInterpreter>(context);
-  arith::ShRSIOp::attachInterface<ArithShRSIOpInterpreter>(context);
-  arith::ShRUIOp::attachInterface<ArithShRUIOpInterpreter>(context);
-  arith::SIToFPOp::attachInterface<ArithSIToFPOpInterpreter>(context);
-  arith::SubFOp::attachInterface<ArithSubFOpInterpreter>(context);
-  arith::TruncFOp::attachInterface<ArithTruncFOpInterpreter>(context);
-  arith::TruncIOp::attachInterface<ArithTruncIOpInterpreter>(context);
-  arith::UIToFPOp::attachInterface<ArithUIToFPOpInterpreter>(context);
-  arith::XOrIOp::attachInterface<ArithXOrIOpInterpreter>(context);
+        auto      resultType      = op->getResult(0).getType();
+        Semantics resultSemantics = getFloatSemantics(resultType);
+        APFloat   result(llvm::APFloatBase::EnumToSemantics(resultSemantics));
+        result.convertFromAPInt(operand, isSigned, llvm::RoundingMode::TowardZero);
+
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(resultType, &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithSubFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithSubFOpInterpreter, arith::SubFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+
+        const APFloat result = lhs - rhs;
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithSubIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithSubIOpInterpreter, arith::SubIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs - rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithTruncFOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithTruncFOpInterpreter, arith::TruncFOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat operand = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand);
+
+        // Get rounding mode from optional attribute
+        llvm::RoundingMode roundingMode = llvm::RoundingMode::NearestTiesToEven;
+#if NEW_LLVM
+        if ( auto modeAttr = op->getAttrOfType<arith::RoundingModeAttr>("roundingmode") ) {
+            roundingMode = convertRoundingMode(modeAttr.getValue());
+            llvm::outs() << mli::fmt::dim("Using specified rounding mode: ") << roundingMode << "\n";
+        }
+#endif
+        llvm::outs() << mli::fmt::dim("Using default rounding mode: NearestTiesToEven") << "\n";
+
+        bool      losesInfo;
+        auto      resultType      = op->getResult(0).getType();
+        Semantics resultSemantics = getFloatSemantics(resultType);
+
+        // Convert using the determined rounding mode
+        APFloat result            = operand;
+        result.convert(llvm::APFloatBase::EnumToSemantics(resultSemantics), roundingMode, &losesInfo);
+
+        if ( losesInfo ) {
+            llvm::outs() << mli::fmt::warning("Precision loss during truncation") << "\n";
+        }
+
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(resultType, &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithTruncIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithTruncIOpInterpreter, arith::TruncIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt operand = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand, isSigned);
+
+        const unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
+        const APInt    result       = operand.trunc(result_width);
+
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithUIToFPOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithUIToFPOpInterpreter, arith::UIToFPOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        bool        isSigned = false;
+        const APInt operand  = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "operand", operand, isSigned);
+
+        auto      resultType      = op->getResult(0).getType();
+        Semantics resultSemantics = getFloatSemantics(resultType);
+        APFloat   result(llvm::APFloatBase::EnumToSemantics(resultSemantics));
+        result.convertFromAPInt(operand, isSigned, llvm::RoundingMode::TowardZero);
+
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(resultType, &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct ArithXOrIOpInterpreter : public InterpreterOpInterface::ExternalModel<ArithXOrIOpInterpreter, arith::XOrIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs ^ rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+}  // end anonymous namespace
+
+void ArithInterpreter::attachInterface(MLIRContext& context) {
+    arith::AddFOp::attachInterface<ArithAddFOpInterpreter>(context);
+    arith::AddIOp::attachInterface<ArithAddIOpInterpreter>(context);
+    arith::AddUIExtendedOp::attachInterface<ArithAddUIExtendedOpInterpreter>(context);
+    arith::AndIOp::attachInterface<ArithAndIOpInterpreter>(context);
+    arith::BitcastOp::attachInterface<ArithBitcastOpInterpreter>(context);
+    arith::CeilDivSIOp::attachInterface<ArithCeilDivSIOpInterpreter>(context);
+    arith::CeilDivUIOp::attachInterface<ArithCeilDivUIOpInterpreter>(context);
+    arith::CmpFOp::attachInterface<ArithCmpFOpInterpreter>(context);
+    arith::CmpIOp::attachInterface<ArithCmpIOpInterpreter>(context);
+    arith::DivFOp::attachInterface<ArithDivFOpInterpreter>(context);
+    arith::DivSIOp::attachInterface<ArithDivSIOpInterpreter>(context);
+    arith::DivUIOp::attachInterface<ArithDivUIOpInterpreter>(context);
+    arith::ExtFOp::attachInterface<ArithExtFOpInterpreter>(context);
+    arith::ExtSIOp::attachInterface<ArithExtSIOpInterpreter>(context);
+    arith::ExtUIOp::attachInterface<ArithExtUIOpInterpreter>(context);
+    arith::ConstantOp::attachInterface<ArithConstantOpInterpreter>(context);
+    arith::IndexCastOp::attachInterface<ArithIndexCastOpInterpreter>(context);
+    arith::IndexCastUIOp::attachInterface<ArithIndexCastUIOpInterpreter>(context);
+    arith::FloorDivSIOp::attachInterface<ArithFloorDivSIOpInterpreter>(context);
+    arith::FPToSIOp::attachInterface<ArithFPToSIOpInterpreter>(context);
+    arith::FPToUIOp::attachInterface<ArithFPToUIOpInterpreter>(context);
+    arith::MaximumFOp::attachInterface<ArithMaximumFOpInterpreter>(context);
+    arith::MaxNumFOp::attachInterface<ArithMaxNumFOpInterpreter>(context);
+    arith::MaxSIOp::attachInterface<ArithMaxSIOpInterpreter>(context);
+    arith::MaxUIOp::attachInterface<ArithMaxUIOpInterpreter>(context);
+    arith::MinimumFOp::attachInterface<ArithMinimumFOpInterpreter>(context);
+    arith::MinNumFOp::attachInterface<ArithMinNumFOpInterpreter>(context);
+    arith::MinSIOp::attachInterface<ArithMinSIOpInterpreter>(context);
+    arith::MinUIOp::attachInterface<ArithMinUIOpInterpreter>(context);
+    arith::MulFOp::attachInterface<ArithMulFOpInterpreter>(context);
+    arith::MulIOp::attachInterface<ArithMulIOpInterpreter>(context);
+    arith::MulSIExtendedOp::attachInterface<ArithMulSIExtendedOpInterpreter>(context);
+    arith::MulUIExtendedOp::attachInterface<ArithMulUIExtendedOpInterpreter>(context);
+    arith::OrIOp::attachInterface<ArithOrIOpInterpreter>(context);
+    arith::NegFOp::attachInterface<ArithNegFOpInterpreter>(context);
+    arith::RemFOp::attachInterface<ArithRemFOpInterpreter>(context);
+    arith::RemSIOp::attachInterface<ArithRemSIOpInterpreter>(context);
+    arith::RemUIOp::attachInterface<ArithRemUIOpInterpreter>(context);
+    arith::SelectOp::attachInterface<ArithSelectOpInterpreter>(context);
+    arith::ShLIOp::attachInterface<ArithShLIOpInterpreter>(context);
+    arith::ShRSIOp::attachInterface<ArithShRSIOpInterpreter>(context);
+    arith::ShRUIOp::attachInterface<ArithShRUIOpInterpreter>(context);
+    arith::SIToFPOp::attachInterface<ArithSIToFPOpInterpreter>(context);
+    arith::SubFOp::attachInterface<ArithSubFOpInterpreter>(context);
+    arith::TruncFOp::attachInterface<ArithTruncFOpInterpreter>(context);
+    arith::TruncIOp::attachInterface<ArithTruncIOpInterpreter>(context);
+    arith::UIToFPOp::attachInterface<ArithUIToFPOpInterpreter>(context);
+    arith::XOrIOp::attachInterface<ArithXOrIOpInterpreter>(context);
 }

--- a/lib/Interpreter/Dialects/CMakeLists.txt
+++ b/lib/Interpreter/Dialects/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ===- lib/Interpreter/Dialects/CMakeLists.txt
 #
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/Interpreter/Dialects/Func/CMakeLists.txt
+++ b/lib/Interpreter/Dialects/Func/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ===- lib/interpreter/dialects/CMakeLists.txt
 #
-#  Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+#  Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 #  All Rights Reserved
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/Interpreter/Dialects/Func/FuncInterpreter.cpp
+++ b/lib/Interpreter/Dialects/Func/FuncInterpreter.cpp
@@ -6,7 +6,7 @@
 //
 // The remaining portions of this file are:
 //
-// Copyright (C) 2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2024-2025 Tactical Computing Laboratories, LLC
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -32,18 +32,15 @@ using namespace mlir;
 
 namespace {
 
-class ReturnOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<ReturnOpInterpreter,
-                                                   func::ReturnOp> {
-public:
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    return interpreter.createReturnValueResult(operands);
-  }
+class ReturnOpInterpreter : public InterpreterOpInterface::ExternalModel<ReturnOpInterpreter, func::ReturnOp> {
+  public:
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        return interpreter.createReturnValueResult(operands);
+    }
 };
 
-} // namespace
+}  // namespace
 
-void FuncInterpreter::attachInterface(MLIRContext &context) {
-  func::ReturnOp::attachInterface<ReturnOpInterpreter>(context);
+void FuncInterpreter::attachInterface(MLIRContext& context) {
+    func::ReturnOp::attachInterface<ReturnOpInterpreter>(context);
 }

--- a/lib/Interpreter/Dialects/LLVM/CMakeLists.txt
+++ b/lib/Interpreter/Dialects/LLVM/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ===- lib/Interpreter/Dialects/LLVM/CMakeLists.txt
 #
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/Interpreter/Dialects/LLVM/LLVMInterpreter.cpp
+++ b/lib/Interpreter/Dialects/LLVM/LLVMInterpreter.cpp
@@ -1,6 +1,6 @@
 //===- LLVMInterpreter.cpp - LLVM dialect interpreter -------------*- C++ -*-===//
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +17,9 @@
 //===----------------------------------------------------------------------===//
 #include "MLIFormat.h"
 #include "MLIUtils.h"
-#include "mlir/Interpreter/Dialects/LLVMInterpreter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/Interpreter/Dialects/LLVMInterpreter.h"
 #include "mlir/Interpreter/Interpreter.h"
 #include "mlir/Interpreter/InterpreterOpInterface.h"
 #include "llvm/ADT/APSInt.h"
@@ -29,1345 +29,1112 @@ using namespace mli;
 
 namespace {
 
-class LLVMReturnOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMReturnOpInterpreter,
-                                                   LLVM::ReturnOp> {
-public:
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << mli::fmt::info("Interpreting LLVM::ReturnOp") << "\n";
-    return interpreter.createReturnValueResult(operands);
-  }
-};
-
-struct LLVMFNegOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFNegOpInterpreter,
-                                                   LLVM::FNegOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = -lhs;
-    mli::fmt::printResult(llvm::outs(), result);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMAddOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMAddOpInterpreter, LLVM::AddOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs + rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFAddOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFAddOpInterpreter,
-                                                   LLVM::FAddOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = lhs + rhs;
-    mli::fmt::printResult(llvm::outs(), result);
-
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMSubOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSubOpInterpreter,
-                                                   LLVM::SubOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs - rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFSubOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFSubOpInterpreter,
-                                                   LLVM::FSubOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = lhs - rhs;
-    mli::fmt::printResult(llvm::outs(), result);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMMulOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMMulOpInterpreter, LLVM::MulOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs * rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFMulOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFMulOpInterpreter,
-                                                   LLVM::FMulOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = lhs * rhs;
-    mli::fmt::printResult(llvm::outs(), result);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMUDivOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMUDivOpInterpreter,
-                                                   LLVM::UDivOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.udiv(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMSDivOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSDivOpInterpreter,
-                                                   LLVM::SDivOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    llvm::outs() << "Interpreting " << op->getName() << "\n";
-    const APInt lhs = getIntegerData(operands[0]);
-    lhs.print(llvm::outs() << "lhs: ", isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    rhs.print(llvm::outs() << "rhs: ", isSigned);
-    const APInt result = lhs.sdiv(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFDivOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFDivOpInterpreter,
-                                                   LLVM::FDivOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = lhs / rhs;
-    mli::fmt::printResult(llvm::outs(), result);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMURemOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMURemOpInterpreter,
-                                                   LLVM::URemOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.urem(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMSRemOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSRemOpInterpreter,
-                                                   LLVM::SRemOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.srem(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFRemOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFRemOpInterpreter,
-                                                   LLVM::FRemOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-
-    APFloat result = lhs;
-    result.mod(rhs);
-
-    mli::fmt::printResult(llvm::outs(), result);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMICmpOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMICmpOpInterpreter,
-                                                   LLVM::ICmpOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    // icmp has various attributes specifying the type of comparison to make
-    LLVM::ICmpPredicate att = op->getAttrOfType<LLVM::ICmpPredicateAttr>("predicate").getValue();
-    bool isSigned = att == LLVM::ICmpPredicate::slt || att == LLVM::ICmpPredicate::sle
-                 || att == LLVM::ICmpPredicate::sgt || att == LLVM::ICmpPredicate::sge;
-
-    llvm::outs() << "Interpreting LLVM::ICmp\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-
-    bool result;
-    llvm::outs() << "attribute: " << att << '\n';
-    switch (att) {
-        case LLVM::ICmpPredicate::ne:
-            result = lhs.ne(rhs);
-            break;
-        case LLVM::ICmpPredicate::slt:
-            result = lhs.slt(rhs);
-            break;
-        case LLVM::ICmpPredicate::sle:
-            result = lhs.sle(rhs);
-            break;
-        case LLVM::ICmpPredicate::sgt:
-            result = lhs.sgt(rhs);
-            break;
-        case LLVM::ICmpPredicate::sge:
-            result = lhs.sge(rhs);
-            break;
-        case LLVM::ICmpPredicate::ult:
-            result = lhs.ult(rhs);
-            break;
-        case LLVM::ICmpPredicate::ule:
-            result = lhs.ule(rhs);
-            break;
-        case LLVM::ICmpPredicate::ugt:
-            result = lhs.ugt(rhs);
-            break;
-        case LLVM::ICmpPredicate::uge:
-            result = lhs.uge(rhs);
-            break;
-        default:
-            result = lhs.eq(rhs);
+class LLVMReturnOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMReturnOpInterpreter, LLVM::ReturnOp> {
+  public:
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << mli::fmt::info("Interpreting LLVM::ReturnOp") << "\n";
+        return interpreter.createReturnValueResult(operands);
     }
-
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
-struct LLVMFCmpOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFCmpOpInterpreter,
-                                                   LLVM::FCmpOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    // FCmp has various attributes specifying the type of comparison to make
-    LLVM::FCmpPredicate att = op->getAttrOfType<LLVM::FCmpPredicateAttr>("predicate").getValue();
-    llvm::outs() << "Interpreting LLVM::FCmp\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-
-    bool lhs_NaN = lhs.isNaN();
-    bool rhs_NaN = rhs.isNaN();
-    bool result;
-    // FCmp supports both ordered and unordered comparisons
-    // Any ordered comparison returns false if at least one argument is NaN
-    // Any unordered comparison returns true if at least one argument is NaN
-    switch (att) {
-        case LLVM::FCmpPredicate::_false:
-            result = false;
-            break;
-        case LLVM::FCmpPredicate::oeq:
-            result = !(lhs_NaN || rhs_NaN) && lhs == rhs;
-            break;
-        case LLVM::FCmpPredicate::ogt:
-            result = !(lhs_NaN || rhs_NaN) && lhs > rhs;
-            break;
-        case LLVM::FCmpPredicate::oge:
-            result = !(lhs_NaN || rhs_NaN) && lhs >= rhs;
-            break;
-        case LLVM::FCmpPredicate::olt:
-            result = !(lhs_NaN || rhs_NaN) && lhs < rhs;
-            break;
-        case LLVM::FCmpPredicate::one:
-            result = !(lhs_NaN || rhs_NaN) && lhs != rhs;
-            break;
-        case LLVM::FCmpPredicate::ord:
-            result = !(lhs_NaN || rhs_NaN);
-            break;
-        case LLVM::FCmpPredicate::ueq:
-            result = lhs_NaN || rhs_NaN || lhs == rhs;
-            break;
-        case LLVM::FCmpPredicate::ugt:
-            result = lhs_NaN || rhs_NaN || lhs > rhs;
-            break;
-        case LLVM::FCmpPredicate::uge:
-            result = lhs_NaN || rhs_NaN || lhs >= rhs;
-            break;
-        case LLVM::FCmpPredicate::ult:
-            result = lhs_NaN || rhs_NaN || lhs < rhs;
-            break;
-        case LLVM::FCmpPredicate::ule:
-            result = lhs_NaN || rhs_NaN || lhs <= rhs;
-            break;
-        case LLVM::FCmpPredicate::une:
-            result = lhs_NaN || rhs_NaN || lhs != rhs;
-            break;
-        case LLVM::FCmpPredicate::uno:
-            result = lhs_NaN || rhs_NaN;
-            break;
-        default:
-            result = true;
-    }
-
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMShlOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMShlOpInterpreter,
-                                                   LLVM::ShlOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.shl(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMLShrOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMLShrOpInterpreter,
-                                                   LLVM::LShrOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.lshr(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMAShrOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMAShrOpInterpreter,
-                                                   LLVM::AShrOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.ashr(rhs);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMAndOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMAndOpInterpreter,
-                                                   LLVM::AndOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs & rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMOrOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMOrOpInterpreter,
-                                                   LLVM::OrOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs | rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMXOrOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMXOrOpInterpreter, LLVM::XOrOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs ^ rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMTruncOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMTruncOpInterpreter,
-                                                   LLVM::TruncOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    unsigned result_width = op->getOpResult(0).getType().getIntOrFloatBitWidth();
-    const APInt result = lhs.trunc(result_width);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFPTruncOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFPTruncOpInterpreter,
-                                                   LLVM::FPTruncOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-
-    bool loseInfo;
-    auto result_type = op->getOpResult(0).getType();
-    APFloat result = lhs;
-    result.convert(llvm::APFloatBase::EnumToSemantics(getFloatSemantics(result_type)), llvm::APFloat::rmTowardZero, &loseInfo);
-
-    mli::fmt::printResult(llvm::outs(), result);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMZExtOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMZExtOpInterpreter,
-                                                   LLVM::ZExtOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true; // garbage value
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-
-    unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
-    const APInt result = lhs.zext(result_width);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMSExtOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSExtOpInterpreter,
-                                                   LLVM::SExtOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-
-    unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
-    llvm::outs() << "Extending to " << result_width << " bits\n";
-    const APInt result = lhs.sext(result_width);
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMBitcastOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMBitcastOpInterpreter,
-                                                   LLVM::BitcastOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    auto src_type = operands[0].getType();
-    auto result_type = op->getOpResult(0).getType();
-    EvalValue evalResult;
-
-    if (src_type == result_type) { // no-op
-        evalResult = operands[0];
-    }
-    else if (llvm::isa<mlir::FloatType>(src_type)) { // src float, ret int
+struct LLVMFNegOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFNegOpInterpreter, LLVM::FNegOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
         const APFloat lhs = getFloatData(operands[0]);
         mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-        const APInt result = lhs.bitcastToAPInt();
+        const APFloat result = -lhs;
         mli::fmt::printResult(llvm::outs(), result);
-        evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
     }
-    else if (llvm::isa<mlir::IntegerType>(src_type)) { // src int, ret float
+};
+
+struct LLVMAddOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMAddOpInterpreter, LLVM::AddOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
         const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs + rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMFAddOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFAddOpInterpreter, LLVM::FAddOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
         mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-        Semantics s = getFloatSemantics(result_type);
-        const APFloat result = APFloat(llvm::APFloat::EnumToSemantics(s), lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = lhs + rhs;
         mli::fmt::printResult(llvm::outs(), result);
-        evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
     }
-    else {
-        llvm::errs() << mli::fmt::warning("Either src or dest is not a numeric type\n");
+};
+
+struct LLVMSubOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSubOpInterpreter, LLVM::SubOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs - rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
     }
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
-struct LLVMFPExtOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFPExtOpInterpreter,
-                                                   LLVM::FPExtOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-
-    bool loseInfo;
-    auto result_type = op->getOpResult(0).getType();
-    APFloat result = lhs;
-    result.convert(llvm::APFloatBase::EnumToSemantics(getFloatSemantics(result_type)), llvm::APFloat::rmTowardZero, &loseInfo);
-
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMFSubOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFSubOpInterpreter, LLVM::FSubOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = lhs - rhs;
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMFPToSIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFPToSIOpInterpreter,
-                                                   LLVM::FPToSIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+struct LLVMMulOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMMulOpInterpreter, LLVM::MulOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs * rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
 
-    unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
-    bool isUnsigned = false;
-    APSInt result = APSInt(result_width, isUnsigned);
-    bool isExact;
-    lhs.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFPToUIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFPToUIOpInterpreter,
-                                                   LLVM::FPToUIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    lhs.print(llvm::outs() << "lhs: ");
-
-    unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
-    bool isUnsigned = true;
-    APSInt result = APSInt(result_width, isUnsigned);
-    bool isExact;
-    lhs.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
-    mli::fmt::printResult(llvm::outs(), result);
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMSIToFPOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSIToFPOpInterpreter,
-                                                   LLVM::SIToFPOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-
-    Semantics sem = getFloatSemantics(op->getResult(0).getType());
-    APFloat result = APFloat(llvm::APFloatBase::EnumToSemantics(sem));
-    result.convertFromAPInt(lhs, isSigned, llvm::RoundingMode::TowardZero);
-
-    mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMUIToFPOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMUIToFPOpInterpreter,
-                                                   LLVM::UIToFPOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-
-    Semantics sem = getFloatSemantics(op->getResult(0).getType());
-    APFloat result = APFloat(llvm::APFloatBase::EnumToSemantics(sem));
-    result.convertFromAPInt(lhs, isSigned, llvm::RoundingMode::TowardZero);
-
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMFMulOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFMulOpInterpreter, LLVM::FMulOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = lhs * rhs;
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMAbsOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMAbsOpInterpreter,
-                                                   LLVM::AbsOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt result = lhs.abs();
+struct LLVMUDivOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMUDivOpInterpreter, LLVM::UDivOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.udiv(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMCosOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMCosOpInterpreter,
-                                                   LLVM::CosOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-
-    const APFloat result = compute(lhs, std::cos);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMSDivOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSDivOpInterpreter, LLVM::SDivOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        llvm::outs() << "Interpreting " << op->getName() << "\n";
+        const APInt lhs = getIntegerData(operands[0]);
+        lhs.print(llvm::outs() << "lhs: ", isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        rhs.print(llvm::outs() << "rhs: ", isSigned);
+        const APInt result = lhs.sdiv(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMExp2OpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMExp2OpInterpreter,
-                                                   LLVM::Exp2Op> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = compute(lhs, std::exp2);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMFDivOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFDivOpInterpreter, LLVM::FDivOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = lhs / rhs;
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMExpOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMExpOpInterpreter,
-                                                   LLVM::ExpOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = compute(lhs, std::exp);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMURemOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMURemOpInterpreter, LLVM::URemOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.urem(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMFAbsOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFAbsOpInterpreter,
-                                                   LLVM::FAbsOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = llvm::abs(lhs);
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFCeilOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFCeilOpInterpreter,
-                                                   LLVM::FCeilOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-
-    APFloat result = lhs;
-    result.roundToIntegral(llvm::RoundingMode::TowardPositive);
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMFFloorOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFFloorOpInterpreter,
-                                                   LLVM::FFloorOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-
-    APFloat result = lhs;
-    result.roundToIntegral(llvm::RoundingMode::TowardNegative);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMSRemOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSRemOpInterpreter, LLVM::SRemOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.srem(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMFMAOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMFMAOpInterpreter,
-                                                   LLVM::FMAOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    APFloat result = getFloatData(operands[2]);
-    result.print(llvm::outs() << "result (before FMA): ");
+struct LLVMFRemOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFRemOpInterpreter, LLVM::FRemOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
 
-    result = lhs * rhs + result;
-    mli::fmt::printResult(llvm::outs(), result);
+        APFloat result = lhs;
+        result.mod(rhs);
+
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMLog10OpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMLog10OpInterpreter,
-                                                   LLVM::Log10Op> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = compute(lhs, std::log10);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMICmpOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMICmpOpInterpreter, LLVM::ICmpOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        // icmp has various attributes specifying the type of comparison to make
+        LLVM::ICmpPredicate att = op->getAttrOfType<LLVM::ICmpPredicateAttr>("predicate").getValue();
+        bool isSigned = att == LLVM::ICmpPredicate::slt || att == LLVM::ICmpPredicate::sle || att == LLVM::ICmpPredicate::sgt ||
+                        att == LLVM::ICmpPredicate::sge;
+
+        llvm::outs() << "Interpreting LLVM::ICmp\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+
+        bool result;
+        llvm::outs() << "attribute: " << att << '\n';
+        switch ( att ) {
+            case LLVM::ICmpPredicate::ne: result = lhs.ne(rhs); break;
+            case LLVM::ICmpPredicate::slt: result = lhs.slt(rhs); break;
+            case LLVM::ICmpPredicate::sle: result = lhs.sle(rhs); break;
+            case LLVM::ICmpPredicate::sgt: result = lhs.sgt(rhs); break;
+            case LLVM::ICmpPredicate::sge: result = lhs.sge(rhs); break;
+            case LLVM::ICmpPredicate::ult: result = lhs.ult(rhs); break;
+            case LLVM::ICmpPredicate::ule: result = lhs.ule(rhs); break;
+            case LLVM::ICmpPredicate::ugt: result = lhs.ugt(rhs); break;
+            case LLVM::ICmpPredicate::uge: result = lhs.uge(rhs); break;
+            default: result = lhs.eq(rhs);
+        }
+
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMLog2OpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMLog2OpInterpreter,
-                                                   LLVM::Log2Op> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = compute(lhs, std::log2);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMFCmpOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFCmpOpInterpreter, LLVM::FCmpOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        // FCmp has various attributes specifying the type of comparison to make
+        LLVM::FCmpPredicate att = op->getAttrOfType<LLVM::FCmpPredicateAttr>("predicate").getValue();
+        llvm::outs() << "Interpreting LLVM::FCmp\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+
+        bool lhs_NaN = lhs.isNaN();
+        bool rhs_NaN = rhs.isNaN();
+        bool result;
+        // FCmp supports both ordered and unordered comparisons
+        // Any ordered comparison returns false if at least one argument is NaN
+        // Any unordered comparison returns true if at least one argument is NaN
+        switch ( att ) {
+            case LLVM::FCmpPredicate::_false: result = false; break;
+            case LLVM::FCmpPredicate::oeq: result = !(lhs_NaN || rhs_NaN) && lhs == rhs; break;
+            case LLVM::FCmpPredicate::ogt: result = !(lhs_NaN || rhs_NaN) && lhs > rhs; break;
+            case LLVM::FCmpPredicate::oge: result = !(lhs_NaN || rhs_NaN) && lhs >= rhs; break;
+            case LLVM::FCmpPredicate::olt: result = !(lhs_NaN || rhs_NaN) && lhs < rhs; break;
+            case LLVM::FCmpPredicate::one: result = !(lhs_NaN || rhs_NaN) && lhs != rhs; break;
+            case LLVM::FCmpPredicate::ord: result = !(lhs_NaN || rhs_NaN); break;
+            case LLVM::FCmpPredicate::ueq: result = lhs_NaN || rhs_NaN || lhs == rhs; break;
+            case LLVM::FCmpPredicate::ugt: result = lhs_NaN || rhs_NaN || lhs > rhs; break;
+            case LLVM::FCmpPredicate::uge: result = lhs_NaN || rhs_NaN || lhs >= rhs; break;
+            case LLVM::FCmpPredicate::ult: result = lhs_NaN || rhs_NaN || lhs < rhs; break;
+            case LLVM::FCmpPredicate::ule: result = lhs_NaN || rhs_NaN || lhs <= rhs; break;
+            case LLVM::FCmpPredicate::une: result = lhs_NaN || rhs_NaN || lhs != rhs; break;
+            case LLVM::FCmpPredicate::uno: result = lhs_NaN || rhs_NaN; break;
+            default: result = true;
+        }
+
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMLogOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMLogOpInterpreter,
-                                                   LLVM::LogOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = compute(lhs, std::log);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMShlOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMShlOpInterpreter, LLVM::ShlOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.shl(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMMinNumOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMMinNumOpInterpreter,
-                                                   LLVM::MinNumOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::MinNum\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = llvm::minnum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMLShrOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMLShrOpInterpreter, LLVM::LShrOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.lshr(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMMinimumOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMMinimumOpInterpreter,
-                                                   LLVM::MinimumOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::Minimum\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = llvm::minimum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMAShrOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMAShrOpInterpreter, LLVM::AShrOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.ashr(rhs);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMMaximumOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMMaximumOpInterpreter,
-                                                   LLVM::MaximumOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::Maximum\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = llvm::maximum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMAndOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMAndOpInterpreter, LLVM::AndOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs & rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMMaxNumOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMMaxNumOpInterpreter,
-                                                   LLVM::MaxNumOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::MaxNum\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = llvm::maxnum(lhs, rhs);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMOrOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMOrOpInterpreter, LLVM::OrOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs | rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMSinOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSinOpInterpreter,
-                                                   LLVM::SinOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = compute(lhs, std::sin);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMXOrOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMXOrOpInterpreter, LLVM::XOrOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs ^ rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMSqrtOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSqrtOpInterpreter,
-                                                   LLVM::SqrtOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::Sqrt\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat result = compute(lhs, std::sqrt);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMTruncOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMTruncOpInterpreter, LLVM::TruncOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        unsigned    result_width = op->getOpResult(0).getType().getIntOrFloatBitWidth();
+        const APInt result       = lhs.trunc(result_width);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMPowOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMPowOpInterpreter,
-                                                   LLVM::PowOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::Pow\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
-    const APFloat result = compute(lhs, rhs, std::pow);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMFPTruncOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFPTruncOpInterpreter, LLVM::FPTruncOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+
+        bool    loseInfo;
+        auto    result_type = op->getOpResult(0).getType();
+        APFloat result      = lhs;
+        result.convert(llvm::APFloatBase::EnumToSemantics(getFloatSemantics(result_type)), llvm::APFloat::rmTowardZero, &loseInfo);
+
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMPowIOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMPowIOpInterpreter,
-                                                   LLVM::PowIOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::PowI\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APInt rhs = getIntegerData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", lhs);
-    const APFloat result = compute(lhs, rhs, std::pow);
-    mli::fmt::printResult(llvm::outs(), result);
+struct LLVMZExtOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMZExtOpInterpreter, LLVM::ZExtOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;  // garbage value
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+
+        unsigned    result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
+        const APInt result       = lhs.zext(result_width);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMSMaxOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSMaxOpInterpreter,
-                                                   LLVM::SMaxOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    llvm::outs() << "Interpreting LLVM::SMax\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.sgt(rhs) ? lhs : rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
+struct LLVMSExtOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSExtOpInterpreter, LLVM::SExtOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
 
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMSMinOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMSMinOpInterpreter,
-                                                   LLVM::SMinOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = true;
-    llvm::outs() << "Interpreting LLVM::SMin\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.slt(rhs) ? lhs : rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
+        unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
+        llvm::outs() << "Extending to " << result_width << " bits\n";
+        const APInt result = lhs.sext(result_width);
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMUMaxOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMUMaxOpInterpreter,
-                                                   LLVM::UMaxOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    llvm::outs() << "Interpreting LLVM::UMax\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.ugt(rhs) ? lhs:rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct LLVMBitcastOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMBitcastOpInterpreter, LLVM::BitcastOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        auto      src_type    = operands[0].getType();
+        auto      result_type = op->getOpResult(0).getType();
+        EvalValue evalResult;
+
+        if ( src_type == result_type ) {  // no-op
+            evalResult = operands[0];
+        }
+        else if ( llvm::isa<mlir::FloatType>(src_type) ) {  // src float, ret int
+            const APFloat lhs = getFloatData(operands[0]);
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+            const APInt result = lhs.bitcastToAPInt();
+            mli::fmt::printResult(llvm::outs(), result);
+            evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+        }
+        else if ( llvm::isa<mlir::IntegerType>(src_type) ) {  // src int, ret float
+            const APInt lhs = getIntegerData(operands[0]);
+            mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+            Semantics     s      = getFloatSemantics(result_type);
+            const APFloat result = APFloat(llvm::APFloat::EnumToSemantics(s), lhs);
+            mli::fmt::printResult(llvm::outs(), result);
+            evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+        }
+        else {
+            llvm::errs() << mli::fmt::warning("Either src or dest is not a numeric type\n");
+        }
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMUMinOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMUMinOpInterpreter,
-                                                   LLVM::UMinOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    llvm::outs() << "Interpreting LLVM::UMin\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt rhs = getIntegerData(operands[1], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
-    const APInt result = lhs.ult(rhs) ? lhs : rhs;
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
+struct LLVMFPExtOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFPExtOpInterpreter, LLVM::FPExtOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+
+        bool    loseInfo;
+        auto    result_type = op->getOpResult(0).getType();
+        APFloat result      = lhs;
+        result.convert(llvm::APFloatBase::EnumToSemantics(getFloatSemantics(result_type)), llvm::APFloat::rmTowardZero, &loseInfo);
+
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(result_type, &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMBitReverseOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMBitReverseOpInterpreter,
-                                                   LLVM::BitReverseOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    llvm::outs() << "Interpreting LLVM::BitReverse\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt result = lhs.reverseBits();
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct LLVMFPToSIOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFPToSIOpInterpreter, LLVM::FPToSIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+
+        unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
+        bool     isUnsigned   = false;
+        APSInt   result       = APSInt(result_width, isUnsigned);
+        bool     isExact;
+        lhs.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMByteSwapOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMByteSwapOpInterpreter,
-                                                   LLVM::ByteSwapOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    llvm::outs() << "Interpreting LLVM::ByteSwap\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    const APInt result = lhs.byteSwap();
-    mli::fmt::printResult(llvm::outs(), result, isSigned);
-        // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+struct LLVMFPToUIOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFPToUIOpInterpreter, LLVM::FPToUIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        lhs.print(llvm::outs() << "lhs: ");
+
+        unsigned result_width = op->getResult(0).getType().getIntOrFloatBitWidth();
+        bool     isUnsigned   = true;
+        APSInt   result       = APSInt(result_width, isUnsigned);
+        bool     isExact;
+        lhs.convertToInteger(result, llvm::RoundingMode::TowardZero, &isExact);
+        mli::fmt::printResult(llvm::outs(), result);
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
-struct LLVMCopySignOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMCopySignOpInterpreter,
-                                                   LLVM::CopySignOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::CopySign\n";
-    const APFloat lhs = getFloatData(operands[0]);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
-    const APFloat rhs = getFloatData(operands[1]);
-    mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+struct LLVMSIToFPOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSIToFPOpInterpreter, LLVM::SIToFPOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
 
-    APFloat result = lhs;
-    result.copySign(rhs);
-    mli::fmt::printResult(llvm::outs(), result);
+        Semantics sem    = getFloatSemantics(op->getResult(0).getType());
+        APFloat   result = APFloat(llvm::APFloatBase::EnumToSemantics(sem));
+        result.convertFromAPInt(lhs, isSigned, llvm::RoundingMode::TowardZero);
+
+        mli::fmt::printResult(llvm::outs(), result);
         // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMUIToFPOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMUIToFPOpInterpreter, LLVM::UIToFPOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+
+        Semantics sem    = getFloatSemantics(op->getResult(0).getType());
+        APFloat   result = APFloat(llvm::APFloatBase::EnumToSemantics(sem));
+        result.convertFromAPInt(lhs, isSigned, llvm::RoundingMode::TowardZero);
+
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMAbsOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMAbsOpInterpreter, LLVM::AbsOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt result = lhs.abs();
+        // Create an EvalValue from the result
+        auto evalResult    = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMCosOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMCosOpInterpreter, LLVM::CosOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+
+        const APFloat result = compute(lhs, std::cos);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMExp2OpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMExp2OpInterpreter, LLVM::Exp2Op> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = compute(lhs, std::exp2);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMExpOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMExpOpInterpreter, LLVM::ExpOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = compute(lhs, std::exp);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMFAbsOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFAbsOpInterpreter, LLVM::FAbsOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = llvm::abs(lhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMFCeilOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFCeilOpInterpreter, LLVM::FCeilOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+
+        APFloat result = lhs;
+        result.roundToIntegral(llvm::RoundingMode::TowardPositive);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMFFloorOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFFloorOpInterpreter, LLVM::FFloorOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+
+        APFloat result = lhs;
+        result.roundToIntegral(llvm::RoundingMode::TowardNegative);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMFMAOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMFMAOpInterpreter, LLVM::FMAOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        APFloat result = getFloatData(operands[2]);
+        result.print(llvm::outs() << "result (before FMA): ");
+
+        result = lhs * rhs + result;
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMLog10OpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMLog10OpInterpreter, LLVM::Log10Op> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = compute(lhs, std::log10);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMLog2OpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMLog2OpInterpreter, LLVM::Log2Op> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = compute(lhs, std::log2);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMLogOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMLogOpInterpreter, LLVM::LogOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = compute(lhs, std::log);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMMinNumOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMMinNumOpInterpreter, LLVM::MinNumOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::MinNum\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = llvm::minnum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMMinimumOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMMinimumOpInterpreter, LLVM::MinimumOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::Minimum\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = llvm::minimum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMMaximumOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMMaximumOpInterpreter, LLVM::MaximumOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::Maximum\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = llvm::maximum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMMaxNumOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMMaxNumOpInterpreter, LLVM::MaxNumOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::MaxNum\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = llvm::maxnum(lhs, rhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMSinOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSinOpInterpreter, LLVM::SinOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = compute(lhs, std::sin);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMSqrtOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSqrtOpInterpreter, LLVM::SqrtOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::Sqrt\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat result = compute(lhs, std::sqrt);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMPowOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMPowOpInterpreter, LLVM::PowOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::Pow\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+        const APFloat result = compute(lhs, rhs, std::pow);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMPowIOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMPowIOpInterpreter, LLVM::PowIOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::PowI\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APInt rhs = getIntegerData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", lhs);
+        const APFloat result = compute(lhs, rhs, std::pow);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMSMaxOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSMaxOpInterpreter, LLVM::SMaxOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        llvm::outs() << "Interpreting LLVM::SMax\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.sgt(rhs) ? lhs : rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMSMinOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMSMinOpInterpreter, LLVM::SMinOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = true;
+        llvm::outs() << "Interpreting LLVM::SMin\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.slt(rhs) ? lhs : rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMUMaxOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMUMaxOpInterpreter, LLVM::UMaxOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        llvm::outs() << "Interpreting LLVM::UMax\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.ugt(rhs) ? lhs : rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMUMinOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMUMinOpInterpreter, LLVM::UMinOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        llvm::outs() << "Interpreting LLVM::UMin\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt rhs = getIntegerData(operands[1], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs, isSigned);
+        const APInt result = lhs.ult(rhs) ? lhs : rhs;
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMBitReverseOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMBitReverseOpInterpreter, LLVM::BitReverseOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        llvm::outs() << "Interpreting LLVM::BitReverse\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt result = lhs.reverseBits();
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMByteSwapOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMByteSwapOpInterpreter, LLVM::ByteSwapOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        llvm::outs() << "Interpreting LLVM::ByteSwap\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        const APInt result = lhs.byteSwap();
+        mli::fmt::printResult(llvm::outs(), result, isSigned);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMCopySignOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMCopySignOpInterpreter, LLVM::CopySignOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::CopySign\n";
+        const APFloat lhs = getFloatData(operands[0]);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs);
+        const APFloat rhs = getFloatData(operands[1]);
+        mli::fmt::printOperand(llvm::outs(), "rhs", rhs);
+
+        APFloat result = lhs;
+        result.copySign(rhs);
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
 struct LLVMCountLeadingZerosOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMCountLeadingZerosOpInterpreter,
-                                                   LLVM::CountLeadingZerosOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    llvm::outs() << "Interpreting LLVM::CountLeadingZeros\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    unsigned result = lhs.countLeadingZeros();
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
+    : public InterpreterOpInterface::ExternalModel<LLVMCountLeadingZerosOpInterpreter, LLVM::CountLeadingZerosOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        llvm::outs() << "Interpreting LLVM::CountLeadingZeros\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        unsigned result = lhs.countLeadingZeros();
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
 };
 
 struct LLVMCountTrailingZerosOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMCountTrailingZerosOpInterpreter,
-                                                   LLVM::CountTrailingZerosOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    llvm::outs() << "Interpreting LLVM::CountLeadingZeros\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-    unsigned result = lhs.countTrailingZeros();
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMCtPopOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMCtPopOpInterpreter,
-                                                   LLVM::CtPopOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    bool isSigned = false;
-    llvm::outs() << "Interpreting LLVM::CtPop\n";
-    const APInt lhs = getIntegerData(operands[0], isSigned);
-    mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
-
-    unsigned result = lhs.popcount();
-    mli::fmt::printResult(llvm::outs(), result);
-    // Create an EvalValue from the result
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMAddressOfOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMAddressOfOpInterpreter, LLVM::AddressOfOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    auto globalName = op->getAttrOfType<StringAttr>("global_name");
-    llvm::outs() << mli::fmt::dim("global_name: ") << mli::fmt::highlight(globalName.getValue().str()) << "\n";
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &globalName, sizeof(globalName));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMAllocaOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMAllocaOpInterpreter, LLVM::AllocaOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
-    auto arraySize = operands[0].getData<int>().front();
-    llvm::outs() << mli::fmt::dim("arraySize: ") << mli::fmt::highlight(std::to_string(arraySize)) << "\n";
-
-    auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &arraySize, sizeof(arraySize));
-    return interpreter.createBindValueResult(evalResult);
-  }
-};
-
-struct LLVMConstantOpInterpreter
-    : public InterpreterOpInterface::ExternalModel<LLVMConstantOpInterpreter,
-                                                   LLVM::ConstantOp> {
-  static EvalResult interpret(Operation *op, Interpreter &interpreter,
-                              ArrayRef<EvalValue> operands) {
-    llvm::outs() << "Interpreting LLVM::Constant\n";
-    auto att = op->getAttr("value");
-    EvalValue evalResult;
-    if (auto int_att = dyn_cast<IntegerAttr>(att)) {
-        const APInt result = int_att.getValue();
-        result.print(llvm::outs() << "Initializing constant ", false);
-        evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
-            }
-    else if (auto float_att = dyn_cast<FloatAttr>(att)) {
-        const APFloat result = float_att.getValue();
-        result.print(llvm::outs() << "Initializing constant ");
-        evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+    : public InterpreterOpInterface::ExternalModel<LLVMCountTrailingZerosOpInterpreter, LLVM::CountTrailingZerosOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        llvm::outs() << "Interpreting LLVM::CountLeadingZeros\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
+        unsigned result = lhs.countTrailingZeros();
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
     }
-    else {
-        llvm::errs() << mli::fmt::warning("Found constant that is neither integer nor float\n");
-    }
-    // Create an EvalValue from the result
-    // Wrap the EvalValue in an ArrayRef and return the EvalResult
-    return interpreter.createBindValueResult(evalResult);
-  }
 };
 
-} // namespace
+struct LLVMCtPopOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMCtPopOpInterpreter, LLVM::CtPopOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        bool isSigned = false;
+        llvm::outs() << "Interpreting LLVM::CtPop\n";
+        const APInt lhs = getIntegerData(operands[0], isSigned);
+        mli::fmt::printOperand(llvm::outs(), "lhs", lhs, isSigned);
 
-void LLVMInterpreter::attachInterface(MLIRContext &context) {
+        unsigned result = lhs.popcount();
+        mli::fmt::printResult(llvm::outs(), result);
+        // Create an EvalValue from the result
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMAddressOfOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMAddressOfOpInterpreter, LLVM::AddressOfOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        auto globalName = op->getAttrOfType<StringAttr>("global_name");
+        llvm::outs() << mli::fmt::dim("global_name: ") << mli::fmt::highlight(globalName.getValue().str()) << "\n";
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &globalName, sizeof(globalName));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMAllocaOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMAllocaOpInterpreter, LLVM::AllocaOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        mli::fmt::printOpName(llvm::outs(), op->getName().getStringRef().str());
+        auto arraySize = operands[0].getData<int>().front();
+        llvm::outs() << mli::fmt::dim("arraySize: ") << mli::fmt::highlight(std::to_string(arraySize)) << "\n";
+
+        auto evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &arraySize, sizeof(arraySize));
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+struct LLVMConstantOpInterpreter : public InterpreterOpInterface::ExternalModel<LLVMConstantOpInterpreter, LLVM::ConstantOp> {
+    static EvalResult interpret(Operation* op, Interpreter& interpreter, ArrayRef<EvalValue> operands) {
+        llvm::outs() << "Interpreting LLVM::Constant\n";
+        auto      att = op->getAttr("value");
+        EvalValue evalResult;
+        if ( auto int_att = dyn_cast<IntegerAttr>(att) ) {
+            const APInt result = int_att.getValue();
+            result.print(llvm::outs() << "Initializing constant ", false);
+            evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        }
+        else if ( auto float_att = dyn_cast<FloatAttr>(att) ) {
+            const APFloat result = float_att.getValue();
+            result.print(llvm::outs() << "Initializing constant ");
+            evalResult = interpreter.createEvalValue(op->getResult(0).getType(), &result, sizeof(result));
+        }
+        else {
+            llvm::errs() << mli::fmt::warning("Found constant that is neither integer nor float\n");
+        }
+        // Create an EvalValue from the result
+        // Wrap the EvalValue in an ArrayRef and return the EvalResult
+        return interpreter.createBindValueResult(evalResult);
+    }
+};
+
+}  // namespace
+
+void LLVMInterpreter::attachInterface(MLIRContext& context) {
     // Arithmetic
     LLVM::FNegOp::attachInterface<LLVMFNegOpInterpreter>(context);
     LLVM::AddOp::attachInterface<LLVMAddOpInterpreter>(context);

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -6,7 +6,7 @@
 //
 // The remaining portions of this file are:
 //
-// Copyright (C) 2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2024-2025 Tactical Computing Laboratories, LLC
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -32,175 +32,159 @@
 using namespace mlir;
 
 EvalValue::EvalValue() : impl(nullptr) {}
-EvalValue::~EvalValue() = default;
-EvalValue::EvalValue(const EvalValue &src) = default;
-EvalValue &EvalValue::operator=(const EvalValue &src) = default;
-EvalValue::EvalValue(EvalValue &&src) = default;
-EvalValue &EvalValue::operator=(EvalValue &&src) = default;
-EvalValue::EvalValue(detail::EvalValueImpl *impl) : impl(impl) {}
 
-Type EvalValue::getType() const { return impl->getType(); }
+EvalValue::~EvalValue()                               = default;
+EvalValue::EvalValue(const EvalValue& src)            = default;
+EvalValue& EvalValue::operator=(const EvalValue& src) = default;
+EvalValue::EvalValue(EvalValue&& src)                 = default;
+EvalValue& EvalValue::operator=(EvalValue&& src)      = default;
+
+EvalValue::EvalValue(detail::EvalValueImpl* impl) : impl(impl) {}
+
+Type EvalValue::getType() const {
+    return impl->getType();
+}
 
 size_t EvalValue::getRawDataSizeInBytes() const {
-  return impl->getRawDataSizeInBytes();
+    return impl->getRawDataSizeInBytes();
 }
 
-char *EvalValue::getRawData() { return impl->getRawData(); }
-
-const char *EvalValue::getRawData() const { return impl->getRawData(); }
-
-Interpreter::Interpreter(MLIRContext &context,
-                         bool enableStackTraceOnError,
-                         std::unique_ptr<MemoryManager> memMgr)
-    : context(&context),
-      enableStackTraceOnError(enableStackTraceOnError),
-      MemManager(std::move(memMgr)) {
-  // If the user didn't supply a MemoryManager, use a simple default.
-  if (!MemManager) {
-    MemManager = std::make_unique<SimpleMemoryManager>(1024 * 1024 * 1024 - 1);
-  }
+char* EvalValue::getRawData() {
+    return impl->getRawData();
 }
 
-EvalResult Interpreter::execute(StringRef entryFuncName,
-                                ArrayRef<EvalValue> arguments) {
-  func::FuncOp func = module.lookupSymbol<func::FuncOp>(entryFuncName);
-  if (!func) {
-    return createErrorResult("failed to find function by name");
-  }
-  return execute(func, arguments);
+const char* EvalValue::getRawData() const {
+    return impl->getRawData();
 }
 
-EvalResult Interpreter::execute(StringRef entryFuncName,
-                                ArgumentProviderRef argumentProvider) {
-  func::FuncOp func = module.lookupSymbol<func::FuncOp>(entryFuncName);
-  if (!func) {
-    return createErrorResult("failed to find function by name");
-  }
-  return execute(func, argumentProvider);
+Interpreter::Interpreter(MLIRContext& context, bool enableStackTraceOnError, std::unique_ptr<MemoryManager> memMgr)
+    : context(&context), enableStackTraceOnError(enableStackTraceOnError), MemManager(std::move(memMgr)) {
+    // If the user didn't supply a MemoryManager, use a simple default.
+    if ( !MemManager ) {
+        MemManager = std::make_unique<SimpleMemoryManager>(1024 * 1024 * 1024 - 1);
+    }
 }
 
-EvalResult Interpreter::execute(func::FuncOp func,
-                                ArrayRef<EvalValue> arguments) {
-  ScopedFunctionFrame functionFrameGuard(*this);
-  return execute(func.getBody(), arguments);
+EvalResult Interpreter::execute(StringRef entryFuncName, ArrayRef<EvalValue> arguments) {
+    func::FuncOp func = module.lookupSymbol<func::FuncOp>(entryFuncName);
+    if ( !func ) {
+        return createErrorResult("failed to find function by name");
+    }
+    return execute(func, arguments);
 }
 
-EvalResult Interpreter::execute(func::FuncOp func,
-                                ArgumentProviderRef argumentProvider) {
-  EvalResult arguments =
-      argumentProvider(*this, func.getFunctionType().getInputs());
-  if (arguments.getKind() != EvalResultKind::BindValue) {
-    return arguments;
-  }
-  return execute(func, arguments.getValues());
+EvalResult Interpreter::execute(StringRef entryFuncName, ArgumentProviderRef argumentProvider) {
+    func::FuncOp func = module.lookupSymbol<func::FuncOp>(entryFuncName);
+    if ( !func ) {
+        return createErrorResult("failed to find function by name");
+    }
+    return execute(func, argumentProvider);
 }
 
-EvalResult Interpreter::execute(Region &region, ArrayRef<EvalValue> arguments) {
-  // Check the region kind.
-  if (Operation *parent_op = region.getParentOp()) {
-    if (parent_op->isRegistered()) {
-      if (auto interface = dyn_cast<RegionKindInterface>(parent_op)) {
-        if (interface.getRegionKind(region.getRegionNumber()) !=
-            RegionKind::SSACFG) {
-          return createErrorResult("only SSACFG region can be interpreted");
+EvalResult Interpreter::execute(func::FuncOp func, ArrayRef<EvalValue> arguments) {
+    ScopedFunctionFrame functionFrameGuard(*this);
+    return execute(func.getBody(), arguments);
+}
+
+EvalResult Interpreter::execute(func::FuncOp func, ArgumentProviderRef argumentProvider) {
+    EvalResult arguments = argumentProvider(*this, func.getFunctionType().getInputs());
+    if ( arguments.getKind() != EvalResultKind::BindValue ) {
+        return arguments;
+    }
+    return execute(func, arguments.getValues());
+}
+
+EvalResult Interpreter::execute(Region& region, ArrayRef<EvalValue> arguments) {
+    // Check the region kind.
+    if ( Operation* parent_op = region.getParentOp() ) {
+        if ( parent_op->isRegistered() ) {
+            if ( auto interface = dyn_cast<RegionKindInterface>(parent_op) ) {
+                if ( interface.getRegionKind(region.getRegionNumber()) != RegionKind::SSACFG ) {
+                    return createErrorResult("only SSACFG region can be interpreted");
+                }
+            }
         }
-      }
     }
-  }
 
-  ScopedRegionFrame regionFrameGuard(*this);
+    ScopedRegionFrame regionFrameGuard(*this);
 
-  // Executes the operations in the blocks.
-  EvalResult result = createBranchResult(region.front(), arguments);
-  while (true) {
-    result = execute(*result.getBlock(), arguments);
-    switch (result.getKind()) {
-    case EvalResultKind::Error:
-      return result;
-    case EvalResultKind::BindValue:
-      return createErrorResult(
-          "region evaluation result must be return or yield");
-    case EvalResultKind::ReturnValue:
-    case EvalResultKind::YieldValue:
-      return result;
-    case EvalResultKind::Branch:
-      break;
+    // Executes the operations in the blocks.
+    EvalResult result = createBranchResult(region.front(), arguments);
+    while ( true ) {
+        result = execute(*result.getBlock(), arguments);
+        switch ( result.getKind() ) {
+            case EvalResultKind::Error: return result;
+            case EvalResultKind::BindValue: return createErrorResult("region evaluation result must be return or yield");
+            case EvalResultKind::ReturnValue:
+            case EvalResultKind::YieldValue: return result;
+            case EvalResultKind::Branch: break;
+        }
     }
-  }
 }
 
-EvalResult Interpreter::execute(Block &block, ArrayRef<EvalValue> arguments) {
-  if (failed(setEvalValues(ValueRange(block.getArguments()), arguments))) {
-    return createErrorResult(
-        "number of formal arguments and actual arguments mismatch");
-  }
-
-  for (auto &op : block) {
-    EvalResult result = execute(op);
-    switch (result.getKind()) {
-    case EvalResultKind::Error:
-      return result;
-    case EvalResultKind::BindValue: {
-      if (failed(
-              setEvalValues(ValueRange(op.getResults()), result.getValues()))) {
-        return createErrorResult("number of op results mismatch");
-      }
-      continue;
+EvalResult Interpreter::execute(Block& block, ArrayRef<EvalValue> arguments) {
+    if ( failed(setEvalValues(ValueRange(block.getArguments()), arguments)) ) {
+        return createErrorResult("number of formal arguments and actual arguments mismatch");
     }
-    case EvalResultKind::ReturnValue:
-    case EvalResultKind::YieldValue:
-    case EvalResultKind::Branch:
-      return result;
+
+    for ( auto& op : block ) {
+        EvalResult result = execute(op);
+        switch ( result.getKind() ) {
+            case EvalResultKind::Error: return result;
+            case EvalResultKind::BindValue:
+                {
+                    if ( failed(setEvalValues(ValueRange(op.getResults()), result.getValues())) ) {
+                        return createErrorResult("number of op results mismatch");
+                    }
+                    continue;
+                }
+            case EvalResultKind::ReturnValue:
+            case EvalResultKind::YieldValue:
+            case EvalResultKind::Branch: return result;
+        }
     }
-  }
 
-  return createErrorResult("block does not end with a terminator op");
+    return createErrorResult("block does not end with a terminator op");
 }
 
-EvalResult Interpreter::execute(Operation &op) {
-  llvm::SmallVector<EvalValue, 8> operands;
-  for (Value operand : op.getOperands()) {
-    operands.push_back(getEvalValue(operand));
-  }
-  return execute(op, operands);
+EvalResult Interpreter::execute(Operation& op) {
+    llvm::SmallVector<EvalValue, 8> operands;
+    for ( Value operand : op.getOperands() ) {
+        operands.push_back(getEvalValue(operand));
+    }
+    return execute(op, operands);
 }
 
-EvalResult Interpreter::execute(Operation &op, ArrayRef<EvalValue> operands) {
-  if (auto interface = dyn_cast<InterpreterOpInterface>(&op)) {
-    return interface.interpret(*this, operands);
-  }
+EvalResult Interpreter::execute(Operation& op, ArrayRef<EvalValue> operands) {
+    if ( auto interface = dyn_cast<InterpreterOpInterface>(&op) ) {
+        return interface.interpret(*this, operands);
+    }
 
-  return createErrorResult("op does not implement InterpreterOpInterface: " +
-                           debugString(op));
+    return createErrorResult("op does not implement InterpreterOpInterface: " + debugString(op));
 }
 
-LogicalResult Interpreter::setEvalValues(ValueRange ssaNames,
-                                         ArrayRef<EvalValue> evalValues) {
-  if (ssaNames.size() != evalValues.size()) {
-    return LogicalResult::failure();
-  }
-  for (auto pair : llvm::zip(ssaNames, evalValues)) {
-    setEvalValue(std::get<0>(pair), std::get<1>(pair));
-  }
-  return LogicalResult::success();
+LogicalResult Interpreter::setEvalValues(ValueRange ssaNames, ArrayRef<EvalValue> evalValues) {
+    if ( ssaNames.size() != evalValues.size() ) {
+        return LogicalResult::failure();
+    }
+    for ( auto pair : llvm::zip(ssaNames, evalValues) ) {
+        setEvalValue(std::get<0>(pair), std::get<1>(pair));
+    }
+    return LogicalResult::success();
 }
 
 EvalResult Interpreter::createErrorResult(StringRef errorMessage) {
-  return EvalResult(
-      EvalResultKind::Error, {}, nullptr,
-      std::make_unique<EvalError>(errorMessage, enableStackTraceOnError));
+    return EvalResult(EvalResultKind::Error, {}, nullptr, std::make_unique<EvalError>(errorMessage, enableStackTraceOnError));
 }
 
 EvalValue Interpreter::createEvalValue(Type type, size_t dataSizeInBytes) {
-  auto implPtr =
-      llvm::makeIntrusiveRefCnt<detail::EvalValueImpl>(type, dataSizeInBytes);
-  return EvalValue(implPtr.get());
+    auto implPtr = llvm::makeIntrusiveRefCnt<detail::EvalValueImpl>(type, dataSizeInBytes);
+    return EvalValue(implPtr.get());
 }
 
-EvalValue Interpreter::createEvalValue(Type type, const void *data,
-                                       size_t dataSizeInBytes) {
-  auto implPtr = llvm::makeIntrusiveRefCnt<detail::EvalValueImpl>(
-    type, llvm::ArrayRef<char>(static_cast<const char *>(data),
-                               dataSizeInBytes));
-  return EvalValue(implPtr.get());
+EvalValue Interpreter::createEvalValue(Type type, const void* data, size_t dataSizeInBytes) {
+    auto implPtr = llvm::makeIntrusiveRefCnt<detail::EvalValueImpl>(
+        type, llvm::ArrayRef<char>(static_cast<const char*>(data), dataSizeInBytes)
+    );
+    return EvalValue(implPtr.get());
 }

--- a/lib/Interpreter/InterpreterOpInterface.cpp
+++ b/lib/Interpreter/InterpreterOpInterface.cpp
@@ -7,66 +7,64 @@
 #include "mlir/Interpreter/InterpreterOpInterface.cpp.inc"
 
 namespace mlir {
-EvalError::EvalError(llvm::StringRef message, bool shouldPrintStackTrace)
-    : message(message.str()) {
-  if (shouldPrintStackTrace) {
-    llvm::raw_string_ostream stream(stacktrace);
-    llvm::sys::PrintStackTrace(stream);
-  }
+EvalError::EvalError(llvm::StringRef message, bool shouldPrintStackTrace) : message(message.str()) {
+    if ( shouldPrintStackTrace ) {
+        llvm::raw_string_ostream stream(stacktrace);
+        llvm::sys::PrintStackTrace(stream);
+    }
 }
 
 llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const EvalValue& val) {
     // Special case i1 = bool
     auto valType = val.getType();
-    if (valType.isInteger(sizeof(bool))) {
+    if ( valType.isInteger(sizeof(bool)) ) {
         auto data = val.getData<bool>();
-        if (!data.empty()) {
+        if ( !data.empty() ) {
             os << data[0];
         }
     }
     // Handle index types
-    else if (valType.isIndex()) {
+    else if ( valType.isIndex() ) {
         auto data = val.getData<intptr_t>();
-        if (!data.empty()) {
+        if ( !data.empty() ) {
             os << data[0];
         }
     }
     // Handle integers
-    else if (valType.isIntOrIndex()) {
+    else if ( valType.isIntOrIndex() ) {
         auto data = val.getData<APInt>();
-        if (!data.empty()) {
+        if ( !data.empty() ) {
             os << data[0];
         }
     }
     // Handle float types
-    else if (mlir::isa<mlir::FloatType>(valType)) {
+    else if ( mlir::isa<mlir::FloatType>(valType) ) {
         auto data = val.getData<APFloat>();
-        if (!data.empty()) {
+        if ( !data.empty() ) {
             data[0].print(os);
         }
     }
     // Handle pointer types
-    else if (mlir::isa<mlir::LLVM::LLVMPointerType>(valType)) {
+    else if ( mlir::isa<mlir::LLVM::LLVMPointerType>(valType) ) {
         auto data = val.getData<uint64_t>();
-        if (!data.empty()) {
+        if ( !data.empty() ) {
             os << "0x";
             os.write_hex(data[0]);
         }
     }
     // Default fallback - show raw bytes in hex
     else {
-        const char* rawData = val.getRawData();
-        size_t dataSize = val.getRawDataSizeInBytes();
+        const char* rawData  = val.getRawData();
+        size_t      dataSize = val.getRawDataSizeInBytes();
 
         os << "0x";
-        for (size_t i = 0; i < dataSize; i++) {
+        for ( size_t i = 0; i < dataSize; i++ ) {
             // Format each byte as hex
             char buffer[3];
-            snprintf(buffer, sizeof(buffer), "%02x", (unsigned char)rawData[i]);
+            snprintf(buffer, sizeof(buffer), "%02x", (unsigned char) rawData[i]);
             os << buffer;
         }
     }
     return os;
 }
-}
-
+}  // namespace mlir

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,79 +1,64 @@
 # ===- src/CMakeLists.txt
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
-# All Rights Reserved
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC All Rights Reserved
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-add_executable(mli
-  MLI.cpp
-)
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+add_executable(mli MLI.cpp)
 
-target_include_directories(mli BEFORE PRIVATE
-  ${CMAKE_SOURCE_DIR}/include
-  ${CMAKE_BINARY_DIR}/include  # Include generated headers
+target_include_directories(mli BEFORE PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include # Include generated headers
 )
 
 # List of required LLVM components
 set(LLVM_LINK_COMPONENTS
-  Core
-  Support
-  Demangle
-  Analysis
-  MC
-  BitReader
-  BitWriter
-  TransformUtils
-  Target
-  Remarks
-)
+    Core
+    Support
+    Demangle
+    Analysis
+    MC
+    BitReader
+    BitWriter
+    TransformUtils
+    Target
+    Remarks)
 
 # Map LLVM components to library names
 llvm_map_components_to_libnames(LLVM_LIBS ${LLVM_LINK_COMPONENTS})
 
 # Link mli executable against necessary libraries
-target_link_libraries(mli
-  PRIVATE
-  MLIRInterpreterLib
-  MLIRIR
-  MLIRArithDialect
-  MLIRFuncDialect
-  MLIRLLVMDialect
-  MLIRSupport
-  MLIRParser
-  MLIRTransforms
-  MLIRBytecodeOpInterface
-  MLIRBytecodeReader
-  MLIRBytecodeWriter
-  LLVMSupport
-  ${LLVM_LIBS}
-)
+target_link_libraries(
+    mli
+    PRIVATE MLIRInterpreterLib
+            MLIRIR
+            MLIRArithDialect
+            MLIRFuncDialect
+            MLIRLLVMDialect
+            MLIRSupport
+            MLIRParser
+            MLIRTransforms
+            MLIRBytecodeOpInterface
+            MLIRBytecodeReader
+            MLIRBytecodeWriter
+            LLVMSupport
+            ${LLVM_LIBS})
 
 # Ensure mli depends on the generated headers
 add_dependencies(mli MLIRInterpreterOpInterfaceIncGen)
 
 if(APPLE)
-  set_target_properties(mli PROPERTIES
-        BUILD_WITH_INSTALL_RPATH TRUE
-        INSTALL_RPATH "@executable_path/../lib"
-        INSTALL_NAME_DIR "@executable_path/../lib"
-    )
+    set_target_properties(
+        mli
+        PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                   INSTALL_RPATH "@executable_path/../lib"
+                   INSTALL_NAME_DIR "@executable_path/../lib")
 else()
-  set_target_properties(mli PROPERTIES
-        BUILD_WITH_INSTALL_RPATH TRUE
-        INSTALL_RPATH "$ORIGIN/../lib"
-    )
+    set_target_properties(mli PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 # Install the executable
-install(TARGETS mli
-  RUNTIME DESTINATION bin
-)
+install(TARGETS mli RUNTIME DESTINATION bin)

--- a/src/MLI.cpp
+++ b/src/MLI.cpp
@@ -1,6 +1,6 @@
 //===- MLI.cpp - Multi-Level Interpreter Driver -------------*- C++ -*-===//
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,69 +16,77 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 #include "MLIExec.h"
-#include "MLIUtils.h"
 #include "MLIFormat.h"
+#include "MLIUtils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Interpreter/Dialects/ArithInterpreter.h"
 #include "mlir/Interpreter/Dialects/FuncInterpreter.h"
 #include "mlir/Interpreter/Dialects/LLVMInterpreter.h"
-#include "mlir/Interpreter/Dialects/ArithInterpreter.h"
 #include "mlir/Interpreter/Interpreter.h"
-#include "mlir/IR/Builders.h"
 #include "llvm/Support/CommandLine.h"
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
 
-  mlir::MLIRContext context;
+    mlir::MLIRContext context;
 
-  // Allow unregistered dialects for now until we adequately support all dialects or 
-  // the ones that persistently show up in the attributes section
-  context.allowUnregisteredDialects();
+    // Allow unregistered dialects for now until we adequately support all dialects or
+    // the ones that persistently show up in the attributes section
+    context.allowUnregisteredDialects();
 
-  // Register command-line options
-  llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional, llvm::cl::desc("<input mlir file>"), llvm::cl::Required);
-  llvm::cl::opt<std::string> funcName("func", llvm::cl::desc("Specify function entry point"), llvm::cl::value_desc("function"), llvm::cl::init("main"));
-  llvm::cl::list<std::string> args("args", llvm::cl::desc("List of numeric arguments"), llvm::cl::CommaSeparated);
-  static llvm::cl::opt<bool, true> printFlag("pretty-print", llvm::cl::desc("Enable ANSI pretty output"), llvm::cl::location(mli::fmt::usePrettyPrint), llvm::cl::init(true));
+    // Register command-line options
+    llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional, llvm::cl::desc("<input mlir file>"), llvm::cl::Required);
+    llvm::cl::opt<std::string> funcName(
+        "func", llvm::cl::desc("Specify function entry point"), llvm::cl::value_desc("function"), llvm::cl::init("main")
+    );
+    llvm::cl::list<std::string>      args("args", llvm::cl::desc("List of numeric arguments"), llvm::cl::CommaSeparated);
+    static llvm::cl::opt<bool, true> printFlag(
+        "pretty-print",
+        llvm::cl::desc("Enable ANSI pretty output"),
+        llvm::cl::location(mli::fmt::usePrettyPrint),
+        llvm::cl::init(true)
+    );
 
-  llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR Interpreter Driver\n");
+    llvm::cl::ParseCommandLineOptions(argc, argv, "MLIR Interpreter Driver\n");
 
-  // Register the necessary dialects
-  context.getOrLoadDialect<mlir::LLVM::LLVMDialect>();
-  context.getOrLoadDialect<mlir::func::FuncDialect>();
-  context.getOrLoadDialect<mlir::arith::ArithDialect>();
+    // Register the necessary dialects
+    context.getOrLoadDialect<mlir::LLVM::LLVMDialect>();
+    context.getOrLoadDialect<mlir::func::FuncDialect>();
+    context.getOrLoadDialect<mlir::arith::ArithDialect>();
 
-  mlir::Interpreter interpreter(context);
+    mlir::Interpreter interpreter(context);
 
-  // Register the necessary interpreters
-  interpreter.registerDialectInterpreter<mlir::FuncInterpreter>();
-  interpreter.registerDialectInterpreter<mlir::LLVMInterpreter>();
-  interpreter.registerDialectInterpreter<mlir::ArithInterpreter>();
+    // Register the necessary interpreters
+    interpreter.registerDialectInterpreter<mlir::FuncInterpreter>();
+    interpreter.registerDialectInterpreter<mlir::LLVMInterpreter>();
+    interpreter.registerDialectInterpreter<mlir::ArithInterpreter>();
 
-  // Parse the MLIR file 
-  auto module = mli::parseMLIRFile(inputFilename, context);
-  if (!module) {
-    return 1;
-  }
-  
-  // Set the module in the interpreter
-  interpreter.setModule(*module);
-
-  // Get the function
-  auto func = module->lookupSymbol<mlir::func::FuncOp>(funcName);
-  if (!func) {
-    llvm::errs() << mli::fmt::error("Function '" + funcName + "' not found in the module.") << "\n";
-    llvm::errs() << "Available functions: ";
-    for (auto &op : module->getOps()) {
-      if (auto funcOp = llvm::dyn_cast<mlir::func::FuncOp>(op)) {
-        llvm::errs() << funcOp.getName() << ", ";
-      } else {
-        llvm::errs() << op.getName() << " is not a func.func operation.\n";
-      }
+    // Parse the MLIR file
+    auto module = mli::parseMLIRFile(inputFilename, context);
+    if ( !module ) {
+        return 1;
     }
-    return 1;
-  }
 
-  return executeFunction(interpreter, func, args, context);
+    // Set the module in the interpreter
+    interpreter.setModule(*module);
+
+    // Get the function
+    auto func = module->lookupSymbol<mlir::func::FuncOp>(funcName);
+    if ( !func ) {
+        llvm::errs() << mli::fmt::error("Function '" + funcName + "' not found in the module.") << "\n";
+        llvm::errs() << "Available functions: ";
+        for ( auto& op : module->getOps() ) {
+            if ( auto funcOp = llvm::dyn_cast<mlir::func::FuncOp>(op) ) {
+                llvm::errs() << funcOp.getName() << ", ";
+            }
+            else {
+                llvm::errs() << op.getName() << " is not a func.func operation.\n";
+            }
+        }
+        return 1;
+    }
+
+    return executeFunction(interpreter, func, args, context);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,7 +63,7 @@ function(add_mli_test)
   # resulting in an empty or "." relative path.
   if(NOT sanitized_path_prefix OR sanitized_path_prefix STREQUAL ".")
     if(sanitized_path_prefix STREQUAL ".")
-      # Request that the operation's test be moved to its constituent dialect subdirectory 
+      # Request that the operation's test be moved to its constituent dialect subdirectory
       set(sanitized_path_prefix "move_this_test_to_its_own_dialect_directory_like_llvm_ir_or_arith")
     endif()
   endif()

--- a/test/mem_manager/testMemory.cpp
+++ b/test/mem_manager/testMemory.cpp
@@ -1,6 +1,6 @@
+#include "mlir/Interpreter/MemoryManager.h"
 #include <cassert>
 #include <iostream>
-#include "mlir/Interpreter/MemoryManager.h"
 
 #define NUM_BLOCKS 3
 
@@ -14,12 +14,13 @@ uint64_t testAlloc(SimpleMemoryManager& mem, const uint64_t size, bool throwExce
     try {
         addr = mem.allocate(size);
         // alloc doesn't throw exception, determine if this is good or bad
-        if (throwException) throw std::runtime_error("No exception thrown!");
+        if ( throwException )
+            throw std::runtime_error("No exception thrown!");
         mem.free(addr);
-    }
-    catch (std::exception& e) {
+    } catch ( std::exception& e ) {
         // Throw a second exception if the test fails
-        if (!throwException || std::string(e.what()) == "No exception thrown") throw std::exception();
+        if ( !throwException || std::string(e.what()) == "No exception thrown" )
+            throw std::exception();
     }
     return addr;
 }
@@ -28,21 +29,22 @@ uint64_t testAlloc(SimpleMemoryManager& mem, const uint64_t size, bool throwExce
 void prepareMemManager(SimpleMemoryManager& mem, const uint64_t* blockSizes, bool openLeft, bool openRight) {
     uint64_t addresses[NUM_BLOCKS];
 
-    for (int i = 0; i < NUM_BLOCKS; i++) {
+    for ( int i = 0; i < NUM_BLOCKS; i++ ) {
         addresses[i] = mem.allocate(blockSizes[i]);
     }
 
-    if (openLeft) mem.free(addresses[0]);
-    if (openRight) mem.free(addresses[2]);
-
+    if ( openLeft )
+        mem.free(addresses[0]);
+    if ( openRight )
+        mem.free(addresses[2]);
 }
 
 int main() {
-    const uint64_t memSize = 100;
+    const uint64_t memSize                = 100;
     const uint64_t blockSizes[NUM_BLOCKS] = {20, 50, 30};
 
     // Case I: Free a region blocked on both sides, no consolidation of freed blocks
-    SimpleMemoryManager mem1 = SimpleMemoryManager(memSize);
+    SimpleMemoryManager mem1              = SimpleMemoryManager(memSize);
     prepareMemManager(mem1, &blockSizes[0], false, false);
 
     // Case II: Free a region blocked only on left side, consolidate freed block w/ right neighbor
@@ -55,27 +57,33 @@ int main() {
 
     // Case IV: Free a region blocked on neither side, consolidate freed block w/ both neighbors
     SimpleMemoryManager mem4 = SimpleMemoryManager(memSize);
-    prepareMemManager(mem4, &blockSizes[0], true, true); 
+    prepareMemManager(mem4, &blockSizes[0], true, true);
 
     const uint64_t middleAddr = 20;
 
     // Case I
     mem1.free(middleAddr);
     assert(testAlloc(mem1, blockSizes[1], false) == middleAddr && "MemManager can't reclaim freed block");
-    testAlloc(mem1, memSize, true); // should fail, not enough space
+    testAlloc(mem1, memSize, true);  // should fail, not enough space
 
     // Case II
     mem2.free(middleAddr);
     assert(testAlloc(mem2, blockSizes[1], false) == middleAddr && "MemManager can't reclaim freed block");
-    assert(testAlloc(mem2, blockSizes[1]+blockSizes[2], false) == middleAddr && "MemManager can't consolidate block with right neighbor");
-    testAlloc(mem2, memSize, true); // should fail, not enough space
+    assert(
+        testAlloc(mem2, blockSizes[1] + blockSizes[2], false) == middleAddr &&
+        "MemManager can't consolidate block with right neighbor"
+    );
+    testAlloc(mem2, memSize, true);  // should fail, not enough space
 
     // Case III
     mem3.free(middleAddr);
     assert(testAlloc(mem3, blockSizes[1], false) == middleAddr - blockSizes[0] && "MemManager can't reclaim freed block");
-    assert(testAlloc(mem3, blockSizes[0]+blockSizes[1], false) == middleAddr - blockSizes[0] && "MemManager can't consolidate block with left neighbor");
-    testAlloc(mem3, memSize, true); // should fail, not enough space
-    
+    assert(
+        testAlloc(mem3, blockSizes[0] + blockSizes[1], false) == middleAddr - blockSizes[0] &&
+        "MemManager can't consolidate block with left neighbor"
+    );
+    testAlloc(mem3, memSize, true);  // should fail, not enough space
+
     // Case IV
     mem4.free(middleAddr);
     assert(testAlloc(mem4, blockSizes[1], false) == 0 && "MemManager can't reclaim freed block");

--- a/test/polygeist/matmul.c
+++ b/test/polygeist/matmul.c
@@ -1,15 +1,15 @@
-#define N 200
-#define M 300
-#define K 400
+#define N         200
+#define M         300
+#define K         400
 #define DATA_TYPE float
 
 void matmul(DATA_TYPE A[N][K], DATA_TYPE B[K][M], DATA_TYPE C[N][M]) {
-  int i, j, k;
-  for (int i = 0; i < N; i++) {
-    for (int j = 0; j < M; j++) {
-      for (int k = 0; k < K; k++) {
-        C[i][j] += A[i][k] * B[k][j];
-      }
+    int i, j, k;
+    for ( int i = 0; i < N; i++ ) {
+        for ( int j = 0; j < M; j++ ) {
+            for ( int k = 0; k < K; k++ ) {
+                C[i][j] += A[i][k] * B[k][j];
+            }
+        }
     }
-  }
 }

--- a/test/polygeist/matmul.cpp
+++ b/test/polygeist/matmul.cpp
@@ -1,15 +1,15 @@
-#define N 200
-#define M 300
-#define K 400
+#define N         200
+#define M         300
+#define K         400
 #define DATA_TYPE float
 
 void matmul(DATA_TYPE A[N][K], DATA_TYPE B[K][M], DATA_TYPE C[N][M]) {
-  int i, j, k;
-  for (int i = 0; i < N; i++) {
-    for (int j = 0; j < M; j++) {
-      for (int k = 0; k < K; k++) {
-        C[i][j] += A[i][k] * B[k][j];
-      }
+    int i, j, k;
+    for ( int i = 0; i < N; i++ ) {
+        for ( int j = 0; j < M; j++ ) {
+            for ( int k = 0; k < K; k++ ) {
+                C[i][j] += A[i][k] * B[k][j];
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
This is a stylistic PR that should have no effect on the workings of the MLI interpreter. I've added a precommit hook that automatically formats documents based on style guidelines. For `C/C++` files, it uses the `.clang_format` present in the top-level directory. The formatting has been applied to the entire codebase, hence the large diff.